### PR TITLE
feat: Tariff-aware battery charging & discharging (Octopus Agile, NordPool, Tibber, G12)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in the Sunsynk integration
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug! Please fill in as much detail as possible so we can reproduce and fix it quickly.
+
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+      placeholder: "e.g. 2025.5.3"
+    validations:
+      required: true
+
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version
+      placeholder: "e.g. 1.5.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: api_server
+    attributes:
+      label: API server
+      options:
+        - api.sunsynk.net (Sunsynk)
+        - pv.inteless.com (Deye / Inteless)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear description of what the bug is and what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Enable debug logging for the integration and paste relevant lines.
+        Add this to `configuration.yaml`:
+        ```yaml
+        logger:
+          logs:
+            custom_components.sunsynk: debug
+        ```
+      render: text
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other information — inverter model, number of inverters, screenshots, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions (Q&A / Help)
+    url: https://github.com/MarcinG81/SunSynk_HA_Integration/discussions
+    about: Ask questions and get help from the community
+  - name: Wiki
+    url: https://github.com/MarcinG81/SunSynk_HA_Integration/wiki
+    about: Installation guides, configuration reference, troubleshooting

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? We'd love to hear it. Please check existing issues and discussions first to avoid duplicates.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this feature solve? What use case drives it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about or tried?
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, links, examples from other integrations, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR do? Why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] Code follows the project style
+- [ ] Self-review performed
+- [ ] Tested against a real inverter / HA instance
+- [ ] `CHANGELOG.md` updated (for user-facing changes)
+- [ ] `manifest.json` version bumped (for releases)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwanted sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the maintainer at **marcin.gaszewski@gmail.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+Thank you for considering a contribution to this project!
+
+## Ways to contribute
+
+- **Bug reports** — open an [issue](https://github.com/MarcinG81/SunSynk_HA_Integration/issues/new/choose) using the bug report template
+- **Feature requests** — open an [issue](https://github.com/MarcinG81/SunSynk_HA_Integration/issues/new/choose) using the feature request template
+- **Discussions** — ask questions or share ideas in [Discussions](https://github.com/MarcinG81/SunSynk_HA_Integration/discussions)
+- **Pull requests** — see below
+
+## Pull requests
+
+1. Fork the repository and create a branch from `main`
+2. Make your changes in `custom_components/sunsynk/`
+3. Test against a real Home Assistant instance with a real or test inverter
+4. Update `CHANGELOG.md` under an `[Unreleased]` section
+5. Open a PR — fill in the PR template
+
+## Development setup
+
+```bash
+git clone https://github.com/<your-fork>/SunSynk_HA_Integration.git
+cd SunSynk_HA_Integration
+```
+
+Copy the `custom_components/sunsynk/` folder into your HA `config/custom_components/` directory and restart HA.
+
+For validation, the repository uses GitHub Actions running **hassfest** and **HACS validation** on every push and PR.
+
+## Code style
+
+- Follow standard Python / Home Assistant integration conventions
+- No external dependencies beyond what is already in `manifest.json`
+- Keep entity names short — `has_entity_name = True` prepends the device name automatically
+
+## Commit messages
+
+Use the conventional commits format:
+
+```
+feat: short description
+fix: short description
+docs: short description
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release receives security fixes.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report security issues privately via [GitHub Security Advisories](https://github.com/MarcinG81/SunSynk_HA_Integration/security/advisories/new) or by emailing **marcin.gaszewski@gmail.com**.
+
+Include:
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+You will receive a response within 48 hours. We will coordinate a fix and disclosure timeline with you.

--- a/custom_components/sunsynk/__init__.py
+++ b/custom_components/sunsynk/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
+from typing import Any
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
@@ -13,18 +14,32 @@ from homeassistant.core import HomeAssistant
 from .api.auth import SunsynkAuth
 from .const import (
     CONF_API_SERVER,
+    CONF_CHEAP_CHARGE_CURRENT,
+    CONF_CHEAP_TARGET_SOC,
+    CONF_CHEAP_THRESHOLD,
+    CONF_DISCHARGE_MIN_SOC,
+    CONF_EXPENSIVE_THRESHOLD,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    CONF_NORMAL_CHARGE_CURRENT,
+    CONF_NORMAL_DISCHARGE_CURRENT,
     CONF_PANEL_KWP,
+    CONF_PEAK_DISCHARGE_CURRENT,
     CONF_PERFORMANCE_RATIO,
+    CONF_PRICE_ENTITY,
     CONF_REFRESH_INTERVAL,
     CONF_SERIALS,
+    CONF_TARIFF_END_HOUR,
+    CONF_TARIFF_START_HOUR,
+    DEFAULT_CHEAP_TARGET_SOC,
+    DEFAULT_DISCHARGE_MIN_SOC,
     DEFAULT_PERFORMANCE_RATIO,
     DEFAULT_REFRESH_INTERVAL,
     DOMAIN,
 )
 from .coordinator import SolarForecastCoordinator, SunsynkCoordinator
 from .dashboard import build_dashboard
+from .tariff import TariffChargingManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,6 +131,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Tariff charging/discharging manager (optional)
+    price_entity = entry.options.get(CONF_PRICE_ENTITY, entry.data.get(CONF_PRICE_ENTITY))
+    if price_entity:
+        def _opt(key: str, default: Any = None) -> Any:
+            return entry.options.get(key, entry.data.get(key, default))
+
+        tariff_manager = TariffChargingManager(
+            hass=hass,
+            coordinator=coordinator,
+            price_entity=price_entity,
+            cheap_threshold=_opt(CONF_CHEAP_THRESHOLD),
+            cheap_current=_opt(CONF_CHEAP_CHARGE_CURRENT),
+            normal_charge_current=_opt(CONF_NORMAL_CHARGE_CURRENT),
+            target_soc=_opt(CONF_CHEAP_TARGET_SOC, DEFAULT_CHEAP_TARGET_SOC),
+            expensive_threshold=_opt(CONF_EXPENSIVE_THRESHOLD),
+            peak_discharge_current=_opt(CONF_PEAK_DISCHARGE_CURRENT),
+            normal_discharge_current=_opt(CONF_NORMAL_DISCHARGE_CURRENT),
+            discharge_min_soc=_opt(CONF_DISCHARGE_MIN_SOC, DEFAULT_DISCHARGE_MIN_SOC),
+            start_hour=_opt(CONF_TARIFF_START_HOUR),
+            end_hour=_opt(CONF_TARIFF_END_HOUR),
+        )
+        tariff_manager.start()
+        hass.data[DOMAIN][f"{entry.entry_id}_tariff"] = tariff_manager
+
     hass.async_create_task(_async_setup_dashboard(hass, entry, coordinator))
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
@@ -133,6 +172,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         if forecast_coordinator is not None:
             await forecast_coordinator.async_close()
+        tariff_manager: TariffChargingManager | None = hass.data[DOMAIN].pop(
+            f"{entry.entry_id}_tariff", None
+        )
+        if tariff_manager is not None:
+            tariff_manager.stop()
 
     return unload_ok
 
@@ -168,7 +212,15 @@ async def _async_setup_dashboard(
     }
     forecast_eid_fn = (lambda key: forecast_uid_map.get(key)) if forecast_uid_map else None
 
-    dashboard_config = build_dashboard(prefix, eid, forecast_eid_fn)
+    tariff_prefix = f"{entry.entry_id}_tariff_"
+    tariff_uid_map: dict[str, str] = {
+        e.unique_id[len(tariff_prefix):]: e.entity_id
+        for e in reg.entities.values()
+        if e.platform == DOMAIN and e.unique_id.startswith(tariff_prefix)
+    }
+    tariff_eid_fn = (lambda key: tariff_uid_map.get(key)) if tariff_uid_map else None
+
+    dashboard_config = build_dashboard(prefix, eid, forecast_eid_fn, tariff_eid_fn)
 
     lovelace = hass.data.get("lovelace")
     dashboards = getattr(lovelace, "dashboards", None)

--- a/custom_components/sunsynk/__init__.py
+++ b/custom_components/sunsynk/__init__.py
@@ -31,7 +31,9 @@ from .const import (
     CONF_SERIALS,
     CONF_TARIFF_END_HOUR,
     CONF_TARIFF_START_HOUR,
+    CONF_PRICE_MAX_AGE,
     DEFAULT_CHEAP_TARGET_SOC,
+    DEFAULT_PRICE_MAX_AGE,
     DEFAULT_DISCHARGE_MIN_SOC,
     DEFAULT_PERFORMANCE_RATIO,
     DEFAULT_REFRESH_INTERVAL,
@@ -151,6 +153,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             discharge_min_soc=_opt(CONF_DISCHARGE_MIN_SOC, DEFAULT_DISCHARGE_MIN_SOC),
             start_hour=_opt(CONF_TARIFF_START_HOUR),
             end_hour=_opt(CONF_TARIFF_END_HOUR),
+            price_max_age_minutes=_opt(CONF_PRICE_MAX_AGE, DEFAULT_PRICE_MAX_AGE),
         )
         tariff_manager.start()
         hass.data[DOMAIN][f"{entry.entry_id}_tariff"] = tariff_manager

--- a/custom_components/sunsynk/config_flow.py
+++ b/custom_components/sunsynk/config_flow.py
@@ -33,9 +33,11 @@ from .const import (
     CONF_SERIALS,
     CONF_TARIFF_END_HOUR,
     CONF_TARIFF_START_HOUR,
+    CONF_PRICE_MAX_AGE,
     DEFAULT_CHEAP_TARGET_SOC,
     DEFAULT_DISCHARGE_MIN_SOC,
     DEFAULT_PERFORMANCE_RATIO,
+    DEFAULT_PRICE_MAX_AGE,
     DEFAULT_REFRESH_INTERVAL,
     DOMAIN,
     MAX_REFRESH_INTERVAL,
@@ -249,6 +251,10 @@ class SunsynkOptionsFlow(config_entries.OptionsFlow):
                 vol.Optional(
                     CONF_TARIFF_END_HOUR, default=_opt(CONF_TARIFF_END_HOUR, "")
                 ): str,
+                # Price quality
+                vol.Optional(
+                    CONF_PRICE_MAX_AGE, default=_opt(CONF_PRICE_MAX_AGE, DEFAULT_PRICE_MAX_AGE)
+                ): vol.All(vol.Coerce(int), vol.Range(min=5, max=1440)),
             }
         )
 
@@ -310,4 +316,5 @@ class SunsynkOptionsFlow(config_entries.OptionsFlow):
             result[CONF_TARIFF_START_HOUR] = start_h
             result[CONF_TARIFF_END_HOUR] = end_h
 
+        result[CONF_PRICE_MAX_AGE] = user_input.get(CONF_PRICE_MAX_AGE, DEFAULT_PRICE_MAX_AGE)
         return result

--- a/custom_components/sunsynk/config_flow.py
+++ b/custom_components/sunsynk/config_flow.py
@@ -9,18 +9,32 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.selector import EntitySelector, EntitySelectorConfig
 
 from .api.auth import SunsynkAuth, SunsynkAuthError
 from .const import (
     API_SERVER_SUNSYNK,
     API_SERVERS,
     CONF_API_SERVER,
+    CONF_CHEAP_CHARGE_CURRENT,
+    CONF_CHEAP_TARGET_SOC,
+    CONF_CHEAP_THRESHOLD,
+    CONF_DISCHARGE_MIN_SOC,
+    CONF_EXPENSIVE_THRESHOLD,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    CONF_NORMAL_CHARGE_CURRENT,
+    CONF_NORMAL_DISCHARGE_CURRENT,
     CONF_PANEL_KWP,
+    CONF_PEAK_DISCHARGE_CURRENT,
     CONF_PERFORMANCE_RATIO,
+    CONF_PRICE_ENTITY,
     CONF_REFRESH_INTERVAL,
     CONF_SERIALS,
+    CONF_TARIFF_END_HOUR,
+    CONF_TARIFF_START_HOUR,
+    DEFAULT_CHEAP_TARGET_SOC,
+    DEFAULT_DISCHARGE_MIN_SOC,
     DEFAULT_PERFORMANCE_RATIO,
     DEFAULT_REFRESH_INTERVAL,
     DOMAIN,
@@ -142,6 +156,17 @@ class SunsynkOptionsFlow(config_entries.OptionsFlow):
                     except (ValueError, TypeError):
                         errors["base"] = "invalid_forecast_config"
 
+                tariff_fields: dict[str, Any] = {}
+                price_entity = user_input.get(CONF_PRICE_ENTITY, "")
+                if price_entity:
+                    tariff_fields[CONF_PRICE_ENTITY] = price_entity
+                    try:
+                        tariff_fields.update(
+                            self._parse_tariff_fields(user_input)
+                        )
+                    except (ValueError, TypeError):
+                        errors["base"] = "invalid_tariff_config"
+
                 if not errors:
                     return self.async_create_entry(
                         title="",
@@ -149,6 +174,7 @@ class SunsynkOptionsFlow(config_entries.OptionsFlow):
                             CONF_REFRESH_INTERVAL: user_input[CONF_REFRESH_INTERVAL],
                             CONF_SERIALS: serials,
                             **forecast_fields,
+                            **tariff_fields,
                         },
                     )
 
@@ -159,11 +185,13 @@ class SunsynkOptionsFlow(config_entries.OptionsFlow):
             CONF_REFRESH_INTERVAL,
             data.get(CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL),
         )
-        # Default to HA home location if not previously overridden
         current_lat = opts.get(CONF_LATITUDE, data.get(CONF_LATITUDE, self.hass.config.latitude))
         current_lon = opts.get(CONF_LONGITUDE, data.get(CONF_LONGITUDE, self.hass.config.longitude))
         current_kwp = opts.get(CONF_PANEL_KWP, data.get(CONF_PANEL_KWP, ""))
         current_pr = opts.get(CONF_PERFORMANCE_RATIO, data.get(CONF_PERFORMANCE_RATIO, ""))
+
+        def _opt(key: str, default: Any = "") -> Any:
+            return opts.get(key, data.get(key, default))
 
         schema = vol.Schema(
             {
@@ -176,12 +204,50 @@ class SunsynkOptionsFlow(config_entries.OptionsFlow):
                     vol.Coerce(int),
                     vol.Range(min=MIN_REFRESH_INTERVAL, max=MAX_REFRESH_INTERVAL),
                 ),
+                # Solar Forecast
                 vol.Optional(CONF_LATITUDE, default=str(current_lat) if current_lat != "" else ""): str,
                 vol.Optional(CONF_LONGITUDE, default=str(current_lon) if current_lon != "" else ""): str,
                 vol.Optional(CONF_PANEL_KWP, default=str(current_kwp) if current_kwp != "" else ""): str,
                 vol.Optional(
                     CONF_PERFORMANCE_RATIO,
                     default=str(current_pr) if current_pr != "" else str(DEFAULT_PERFORMANCE_RATIO),
+                ): str,
+                # Tariff — shared price sensor
+                vol.Optional(
+                    CONF_PRICE_ENTITY, default=_opt(CONF_PRICE_ENTITY)
+                ): EntitySelector(EntitySelectorConfig(domain=["sensor", "input_number"])),
+                # Cheap-rate charging
+                vol.Optional(
+                    CONF_CHEAP_THRESHOLD, default=_opt(CONF_CHEAP_THRESHOLD, "")
+                ): str,
+                vol.Optional(
+                    CONF_CHEAP_CHARGE_CURRENT, default=_opt(CONF_CHEAP_CHARGE_CURRENT, "")
+                ): str,
+                vol.Optional(
+                    CONF_NORMAL_CHARGE_CURRENT, default=_opt(CONF_NORMAL_CHARGE_CURRENT, "")
+                ): str,
+                vol.Optional(
+                    CONF_CHEAP_TARGET_SOC, default=_opt(CONF_CHEAP_TARGET_SOC, DEFAULT_CHEAP_TARGET_SOC)
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=100)),
+                # Expensive-rate discharging
+                vol.Optional(
+                    CONF_EXPENSIVE_THRESHOLD, default=_opt(CONF_EXPENSIVE_THRESHOLD, "")
+                ): str,
+                vol.Optional(
+                    CONF_PEAK_DISCHARGE_CURRENT, default=_opt(CONF_PEAK_DISCHARGE_CURRENT, "")
+                ): str,
+                vol.Optional(
+                    CONF_NORMAL_DISCHARGE_CURRENT, default=_opt(CONF_NORMAL_DISCHARGE_CURRENT, "")
+                ): str,
+                vol.Optional(
+                    CONF_DISCHARGE_MIN_SOC, default=_opt(CONF_DISCHARGE_MIN_SOC, DEFAULT_DISCHARGE_MIN_SOC)
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=90)),
+                # Scheduler (both blank = always active)
+                vol.Optional(
+                    CONF_TARIFF_START_HOUR, default=_opt(CONF_TARIFF_START_HOUR, "")
+                ): str,
+                vol.Optional(
+                    CONF_TARIFF_END_HOUR, default=_opt(CONF_TARIFF_END_HOUR, "")
                 ): str,
             }
         )
@@ -191,3 +257,57 @@ class SunsynkOptionsFlow(config_entries.OptionsFlow):
             data_schema=schema,
             errors=errors,
         )
+
+    @staticmethod
+    def _parse_tariff_fields(user_input: dict[str, Any]) -> dict[str, Any]:
+        """Parse and validate optional tariff numeric fields."""
+        result: dict[str, Any] = {}
+
+        def _parse_float(key: str) -> float | None:
+            raw = str(user_input.get(key, "")).strip()
+            return float(raw) if raw else None
+
+        def _parse_int(key: str) -> int | None:
+            raw = str(user_input.get(key, "")).strip()
+            return int(raw) if raw else None
+
+        cheap_thr = _parse_float(CONF_CHEAP_THRESHOLD)
+        cheap_amp = _parse_int(CONF_CHEAP_CHARGE_CURRENT)
+        normal_amp = _parse_int(CONF_NORMAL_CHARGE_CURRENT)
+
+        if any(v is not None for v in (cheap_thr, cheap_amp, normal_amp)):
+            if not all(v is not None for v in (cheap_thr, cheap_amp, normal_amp)):
+                raise ValueError("Cheap charging requires threshold, charge current, and normal current")
+            if cheap_amp <= 0 or normal_amp <= 0:  # type: ignore[operator]
+                raise ValueError("Charge currents must be positive")
+            result[CONF_CHEAP_THRESHOLD] = cheap_thr
+            result[CONF_CHEAP_CHARGE_CURRENT] = cheap_amp
+            result[CONF_NORMAL_CHARGE_CURRENT] = normal_amp
+            result[CONF_CHEAP_TARGET_SOC] = user_input.get(CONF_CHEAP_TARGET_SOC, DEFAULT_CHEAP_TARGET_SOC)
+
+        exp_thr = _parse_float(CONF_EXPENSIVE_THRESHOLD)
+        peak_amp = _parse_int(CONF_PEAK_DISCHARGE_CURRENT)
+        normal_dis_amp = _parse_int(CONF_NORMAL_DISCHARGE_CURRENT)
+
+        if any(v is not None for v in (exp_thr, peak_amp, normal_dis_amp)):
+            if not all(v is not None for v in (exp_thr, peak_amp, normal_dis_amp)):
+                raise ValueError("Discharge requires threshold, peak discharge current, and normal discharge current")
+            if peak_amp <= 0 or normal_dis_amp <= 0:  # type: ignore[operator]
+                raise ValueError("Discharge currents must be positive")
+            result[CONF_EXPENSIVE_THRESHOLD] = exp_thr
+            result[CONF_PEAK_DISCHARGE_CURRENT] = peak_amp
+            result[CONF_NORMAL_DISCHARGE_CURRENT] = normal_dis_amp
+            result[CONF_DISCHARGE_MIN_SOC] = user_input.get(CONF_DISCHARGE_MIN_SOC, DEFAULT_DISCHARGE_MIN_SOC)
+
+        start_raw = str(user_input.get(CONF_TARIFF_START_HOUR, "")).strip()
+        end_raw = str(user_input.get(CONF_TARIFF_END_HOUR, "")).strip()
+        if start_raw or end_raw:
+            if not (start_raw and end_raw):
+                raise ValueError("Schedule requires both start hour and end hour")
+            start_h, end_h = int(start_raw), int(end_raw)
+            if not (0 <= start_h <= 23 and 0 <= end_h <= 23):
+                raise ValueError("Hours must be 0–23")
+            result[CONF_TARIFF_START_HOUR] = start_h
+            result[CONF_TARIFF_END_HOUR] = end_h
+
+        return result

--- a/custom_components/sunsynk/const.py
+++ b/custom_components/sunsynk/const.py
@@ -46,6 +46,21 @@ CONF_PERFORMANCE_RATIO: Final = "performance_ratio"
 DEFAULT_PERFORMANCE_RATIO: Final = 0.80
 SOLAR_FORECAST_UPDATE_INTERVAL: Final = 30  # minutes
 
+# Tariff-aware charging / discharging
+CONF_PRICE_ENTITY: Final = "price_entity"
+CONF_CHEAP_THRESHOLD: Final = "cheap_threshold"
+CONF_CHEAP_CHARGE_CURRENT: Final = "cheap_charge_current"
+CONF_NORMAL_CHARGE_CURRENT: Final = "normal_charge_current"
+CONF_CHEAP_TARGET_SOC: Final = "cheap_target_soc"
+DEFAULT_CHEAP_TARGET_SOC: Final = 100
+CONF_EXPENSIVE_THRESHOLD: Final = "expensive_threshold"
+CONF_PEAK_DISCHARGE_CURRENT: Final = "peak_discharge_current"
+CONF_NORMAL_DISCHARGE_CURRENT: Final = "normal_discharge_current"
+CONF_DISCHARGE_MIN_SOC: Final = "discharge_min_soc"
+DEFAULT_DISCHARGE_MIN_SOC: Final = 10
+CONF_TARIFF_START_HOUR: Final = "tariff_start_hour"
+CONF_TARIFF_END_HOUR: Final = "tariff_end_hour"
+
 
 @dataclass(frozen=True)
 class SunsynkSensorEntityDescription(SensorEntityDescription):

--- a/custom_components/sunsynk/const.py
+++ b/custom_components/sunsynk/const.py
@@ -60,6 +60,8 @@ CONF_DISCHARGE_MIN_SOC: Final = "discharge_min_soc"
 DEFAULT_DISCHARGE_MIN_SOC: Final = 10
 CONF_TARIFF_START_HOUR: Final = "tariff_start_hour"
 CONF_TARIFF_END_HOUR: Final = "tariff_end_hour"
+CONF_PRICE_MAX_AGE: Final = "price_max_age"
+DEFAULT_PRICE_MAX_AGE: Final = 90  # minutes
 
 
 @dataclass(frozen=True)

--- a/custom_components/sunsynk/dashboard.py
+++ b/custom_components/sunsynk/dashboard.py
@@ -8,6 +8,7 @@ def build_dashboard(
     prefix: str,
     eid: Callable[[str], str | None] | None = None,
     forecast_eid: Callable[[str], str | None] | None = None,
+    tariff_eid: Callable[[str], str | None] | None = None,
 ) -> dict[str, Any]:
     """Return a full Lovelace dashboard config dict with correct entity IDs.
 
@@ -101,6 +102,10 @@ def build_dashboard(
     fc_ghi      = fc("forecast_ghi",          "solar_forecast_ghi")
     fc_dni      = fc("forecast_dni",          "solar_forecast_dni")
     has_forecast = fc_today is not None
+
+    # Tariff entity IDs — only populated when tariff manager is configured
+    tariff_mode = tariff_eid("tariff_mode") if tariff_eid else None
+    has_tariff = tariff_mode is not None
 
     return {
         "views": [
@@ -237,6 +242,16 @@ def build_dashboard(
                                     ],
                                 },
                             ] if has_forecast else []),
+                            *([
+                                {
+                                    "type": "entities",
+                                    "title": "Tariff Manager",
+                                    "entities": [
+                                        {"entity": f"switch.{prefix}_tariff_manager", "name": "Enable Tariff Manager"},
+                                        {"entity": tariff_mode, "name": "Current Mode"},
+                                    ],
+                                },
+                            ] if has_tariff else []),
                         ],
                     }
                 ],
@@ -300,6 +315,17 @@ def build_dashboard(
                             {"entity": inv_ac_temp, "name": "AC (IGBT)"},
                         ],
                     },
+                    *([
+                        {
+                            "type": "history-graph",
+                            "title": "Tariff Manager — last 24 hours",
+                            "hours_to_show": 24,
+                            "entities": [
+                                {"entity": tariff_mode, "name": "Mode"},
+                                {"entity": bat_soc, "name": "SOC"},
+                            ],
+                        },
+                    ] if has_tariff else []),
                 ],
             },
 

--- a/custom_components/sunsynk/sensor.py
+++ b/custom_components/sunsynk/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -32,7 +33,7 @@ from .const import (
 )
 from .coordinator import SolarForecastCoordinator, SunsynkCoordinator
 from .helpers import build_device_info
-from .tariff import TariffChargingManager
+from .tariff import QUALITY_OK, TariffChargingManager
 
 
 @dataclass(frozen=True)
@@ -153,7 +154,10 @@ async def async_setup_entry(
     if tariff_manager is not None:
         first_serial = coordinator.serials[0]
         device_info = build_device_info(coordinator, first_serial)
-        async_add_entities([TariffStateSensor(entry.entry_id, tariff_manager, device_info)])
+        async_add_entities([
+            TariffStateSensor(entry.entry_id, tariff_manager, device_info),
+            TariffPriceQualitySensor(entry.entry_id, tariff_manager, device_info),
+        ])
 
 
 
@@ -353,4 +357,58 @@ class TariffStateSensor(SensorEntity):
             attrs["expensive_threshold"] = self._manager.expensive_threshold
         if self._manager.start_hour is not None:
             attrs["active_hours"] = f"{self._manager.start_hour:02d}:00–{self._manager.end_hour:02d}:00"
+        return attrs
+
+
+class TariffPriceQualitySensor(SensorEntity):
+    """Diagnostic sensor reporting price data quality for the tariff manager.
+
+    States: ok | unavailable | not_found | invalid | stale
+    """
+
+    _attr_has_entity_name = True
+    _attr_name = "Tariff Price Quality"
+    _attr_icon = "mdi:check-circle"
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        entry_id: str,
+        manager: TariffChargingManager,
+        device_info: DeviceInfo,
+    ) -> None:
+        self._manager = manager
+        self._attr_unique_id = f"{entry_id}_tariff_price_quality"
+        self._attr_device_info = device_info
+        self._unsub: Any = None
+
+    async def async_added_to_hass(self) -> None:
+        self._unsub = self._manager.async_add_listener(self._handle_update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._unsub:
+            self._unsub()
+            self._unsub = None
+
+    @callback
+    def _handle_update(self) -> None:
+        quality = self._manager.price_quality
+        self._attr_icon = "mdi:check-circle" if quality == QUALITY_OK else "mdi:alert-circle"
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> str:
+        return self._manager.price_quality
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {"price_entity": self._manager.price_entity}
+        if self._manager.price_max_age_minutes is not None:
+            attrs["max_age_minutes"] = self._manager.price_max_age_minutes
+        # Attach live sensor details when available
+        state = self.hass.states.get(self._manager.price_entity) if self.hass else None
+        if state is not None:
+            attrs["last_updated"] = state.last_updated.isoformat()
+            attrs["current_state"] = state.state
         return attrs

--- a/custom_components/sunsynk/sensor.py
+++ b/custom_components/sunsynk/sensor.py
@@ -32,6 +32,7 @@ from .const import (
 )
 from .coordinator import SolarForecastCoordinator, SunsynkCoordinator
 from .helpers import build_device_info
+from .tariff import TariffChargingManager
 
 
 @dataclass(frozen=True)
@@ -145,6 +146,14 @@ async def async_setup_entry(
             SolarForecastSensor(forecast_coordinator, entry.entry_id, desc, forecast_device)
             for desc in FORECAST_SENSOR_DESCRIPTIONS
         ])
+
+    tariff_manager: TariffChargingManager | None = hass.data[DOMAIN].get(
+        f"{entry.entry_id}_tariff"
+    )
+    if tariff_manager is not None:
+        first_serial = coordinator.serials[0]
+        device_info = build_device_info(coordinator, first_serial)
+        async_add_entities([TariffStateSensor(entry.entry_id, tariff_manager, device_info)])
 
 
 
@@ -298,3 +307,50 @@ class SolarForecastSensor(CoordinatorEntity[SolarForecastCoordinator], SensorEnt
         if self.coordinator.data is None:
             return None
         return self.coordinator.data.get(self.entity_description.forecast_key)
+
+
+class TariffStateSensor(SensorEntity):
+    """Sensor reporting the current operating mode of the tariff manager."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Tariff Mode"
+    _attr_icon = "mdi:lightning-bolt"
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        entry_id: str,
+        manager: TariffChargingManager,
+        device_info: DeviceInfo,
+    ) -> None:
+        self._manager = manager
+        self._attr_unique_id = f"{entry_id}_tariff_mode"
+        self._attr_device_info = device_info
+        self._unsub: Any = None
+
+    async def async_added_to_hass(self) -> None:
+        self._unsub = self._manager.async_add_listener(self._handle_update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._unsub:
+            self._unsub()
+            self._unsub = None
+
+    @callback
+    def _handle_update(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> str:
+        return self._manager.mode
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {"price_entity": self._manager.price_entity}
+        if self._manager.cheap_threshold is not None:
+            attrs["cheap_threshold"] = self._manager.cheap_threshold
+        if self._manager.expensive_threshold is not None:
+            attrs["expensive_threshold"] = self._manager.expensive_threshold
+        if self._manager.start_hour is not None:
+            attrs["active_hours"] = f"{self._manager.start_hour:02d}:00–{self._manager.end_hour:02d}:00"
+        return attrs

--- a/custom_components/sunsynk/strings.json
+++ b/custom_components/sunsynk/strings.json
@@ -36,19 +36,42 @@
           "latitude": "Latitude (Solar Forecast)",
           "longitude": "Longitude (Solar Forecast)",
           "panel_kwp": "Panel Peak Power (kWp)",
-          "performance_ratio": "Performance Ratio (0–1)"
+          "performance_ratio": "Performance Ratio (0–1)",
+          "price_entity": "Electricity Price Sensor",
+          "cheap_threshold": "Charge below price (cheap rate threshold)",
+          "cheap_charge_current": "Charge current at cheap rate (A)",
+          "normal_charge_current": "Normal charge current to restore (A)",
+          "cheap_target_soc": "Stop charging when SOC reaches (%)",
+          "expensive_threshold": "Discharge above price (expensive rate threshold)",
+          "peak_discharge_current": "Discharge current at expensive rate (A)",
+          "normal_discharge_current": "Normal discharge current to restore (A)",
+          "discharge_min_soc": "Stop discharging when SOC drops below (%)",
+          "tariff_start_hour": "Active schedule — start hour (0–23)",
+          "tariff_end_hour": "Active schedule — end hour (0–23)"
         },
         "data_description": {
           "latitude": "Optional — defaults to your HA home location",
           "longitude": "Optional — defaults to your HA home location",
           "panel_kwp": "Total installed panel capacity in kilowatt-peak. Leave blank to disable solar forecast.",
-          "performance_ratio": "System efficiency factor, default 0.80"
+          "performance_ratio": "System efficiency factor, default 0.80",
+          "price_entity": "Any sensor reporting electricity price (e.g. Octopus Agile, NordPool, Tibber). Leave blank to disable tariff management.",
+          "cheap_threshold": "When price ≤ this value, charge the battery. Leave blank to disable cheap-rate charging.",
+          "cheap_charge_current": "Battery charge current during cheap period (e.g. 100 A).",
+          "normal_charge_current": "Charge current restored when cheap period ends.",
+          "cheap_target_soc": "Charging stops automatically once battery reaches this SOC. Default 100.",
+          "expensive_threshold": "When price ≥ this value, discharge the battery (sell to grid). Leave blank to disable.",
+          "peak_discharge_current": "Battery discharge current during expensive period (e.g. 100 A).",
+          "normal_discharge_current": "Discharge current restored when expensive period ends.",
+          "discharge_min_soc": "Discharging stops automatically when battery reaches this SOC. Default 10.",
+          "tariff_start_hour": "Hour of day (0–23) when tariff management activates. Leave blank for always-on.",
+          "tariff_end_hour": "Hour of day (0–23) when tariff management deactivates. Can wrap midnight (e.g. start 22, end 6)."
         }
       }
     },
     "error": {
       "invalid_serials": "Invalid serial number(s). Enter at least one serial.",
-      "invalid_forecast_config": "Solar forecast requires valid latitude, longitude and panel kWp (all numeric, kWp > 0)."
+      "invalid_forecast_config": "Solar forecast requires valid latitude, longitude and panel kWp (all numeric, kWp > 0).",
+      "invalid_tariff_config": "Tariff configuration error. Cheap charging needs threshold + charge current + normal current (all three). Discharge needs threshold + peak current + normal current (all three)."
     }
   }
 }

--- a/custom_components/sunsynk/strings.json
+++ b/custom_components/sunsynk/strings.json
@@ -47,7 +47,8 @@
           "normal_discharge_current": "Normal discharge current to restore (A)",
           "discharge_min_soc": "Stop discharging when SOC drops below (%)",
           "tariff_start_hour": "Active schedule — start hour (0–23)",
-          "tariff_end_hour": "Active schedule — end hour (0–23)"
+          "tariff_end_hour": "Active schedule — end hour (0–23)",
+          "price_max_age": "Price data max age (minutes)"
         },
         "data_description": {
           "latitude": "Optional — defaults to your HA home location",
@@ -64,7 +65,8 @@
           "normal_discharge_current": "Discharge current restored when expensive period ends.",
           "discharge_min_soc": "Discharging stops automatically when battery reaches this SOC. Default 10.",
           "tariff_start_hour": "Hour of day (0–23) when tariff management activates. Leave blank for always-on.",
-          "tariff_end_hour": "Hour of day (0–23) when tariff management deactivates. Can wrap midnight (e.g. start 22, end 6)."
+          "tariff_end_hour": "Hour of day (0–23) when tariff management deactivates. Can wrap midnight (e.g. start 22, end 6).",
+          "price_max_age": "If the price sensor has not updated within this many minutes, any active charge/discharge mode is stopped as a safety measure. Default 90. Set high to effectively disable the check."
         }
       }
     },

--- a/custom_components/sunsynk/switch.py
+++ b/custom_components/sunsynk/switch.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -14,6 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import SunsynkCoordinator
 from .helpers import build_device_info
+from .tariff import TariffChargingManager
 
 
 @dataclass(frozen=True)
@@ -187,12 +189,22 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: SunsynkCoordinator = hass.data[DOMAIN][entry.entry_id]
-    entities: list[SunsynkSwitchEntity] = []
+    entities: list[SunsynkSwitchEntity | TariffManagerSwitch] = []
 
     for serial in coordinator.serials:
         device_info = build_device_info(coordinator, serial)
         for description in WRITABLE_SWITCHES:
             entities.append(SunsynkSwitchEntity(coordinator, serial, description, device_info))
+
+    tariff_manager: TariffChargingManager | None = hass.data[DOMAIN].get(
+        f"{entry.entry_id}_tariff"
+    )
+    if tariff_manager is not None:
+        first_serial = coordinator.serials[0]
+        device_info = build_device_info(coordinator, first_serial)
+        entities.append(
+            TariffManagerSwitch(entry.entry_id, tariff_manager, device_info)
+        )
 
     async_add_entities(entities)
 
@@ -237,3 +249,46 @@ class SunsynkSwitchEntity(CoordinatorEntity[SunsynkCoordinator], SwitchEntity):
         await self.coordinator.async_write_setting(
             self._serial, self.entity_description.setting_key, 0
         )
+
+
+class TariffManagerSwitch(SwitchEntity):
+    """Enable / disable the tariff charging+discharging manager without losing config."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Tariff Manager"
+    _attr_icon = "mdi:currency-sign"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        entry_id: str,
+        manager: TariffChargingManager,
+        device_info: DeviceInfo,
+    ) -> None:
+        self._manager = manager
+        self._unsub: Any = None
+        self._attr_unique_id = f"{entry_id}_tariff_enabled"
+        self._attr_device_info = device_info
+
+    async def async_added_to_hass(self) -> None:
+        self._unsub = self._manager.async_add_listener(self._handle_update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._unsub:
+            self._unsub()
+            self._unsub = None
+
+    @callback
+    def _handle_update(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool:
+        return self._manager.is_enabled
+
+    async def async_turn_on(self, **kwargs) -> None:
+        self._manager.set_enabled(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        self._manager.set_enabled(False)

--- a/custom_components/sunsynk/tariff.py
+++ b/custom_components/sunsynk/tariff.py
@@ -7,12 +7,20 @@ from typing import Any, Callable
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.util import dt as dt_util
 
 from .coordinator import SunsynkCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 _NOTIFICATION_ID = "sunsynk_tariff"
+
+# Human-readable quality state values
+QUALITY_OK = "ok"
+QUALITY_NOT_FOUND = "not_found"
+QUALITY_UNAVAILABLE = "unavailable"
+QUALITY_INVALID = "invalid"
+QUALITY_STALE = "stale"
 
 
 class TariffChargingManager:
@@ -31,6 +39,11 @@ class TariffChargingManager:
     An optional schedule (start_hour / end_hour) limits activity to
     specific hours of the day.  If start_hour > end_hour the range
     wraps midnight (e.g., 22–06).
+
+    price_max_age_minutes: if the price sensor has not updated within
+    this many minutes the data is considered stale and any active mode
+    is cancelled to avoid acting on outdated prices.  Pass None to
+    skip the staleness check.
     """
 
     def __init__(
@@ -51,6 +64,8 @@ class TariffChargingManager:
         # schedule (both None = always active)
         start_hour: int | None = None,
         end_hour: int | None = None,
+        # price data quality
+        price_max_age_minutes: int | None = 90,
     ) -> None:
         self._hass = hass
         self._coordinator = coordinator
@@ -68,10 +83,12 @@ class TariffChargingManager:
 
         self._start_hour = start_hour
         self._end_hour = end_hour
+        self._price_max_age_minutes = price_max_age_minutes
 
         self._enabled = False  # user must explicitly enable via switch
         self._charging_active = False
         self._discharging_active = False
+        self._price_quality: str = QUALITY_NOT_FOUND
         self._listeners: list[Callable[[], None]] = []
         self._unsub_price: Any = None
         self._unsub_coordinator: Any = None
@@ -99,21 +116,14 @@ class TariffChargingManager:
         self._unsub_coordinator = self._coordinator.async_add_listener(
             self._on_coordinator_update
         )
-        state = self._hass.states.get(self._price_entity)
-        if state is None:
-            _LOGGER.warning("Tariff: price entity '%s' not found", self._price_entity)
-        elif state.state in ("unknown", "unavailable"):
+        # Assess initial quality and log result
+        quality, _ = self._compute_price_quality()
+        self._price_quality = quality
+        if quality != QUALITY_OK:
             _LOGGER.warning(
-                "Tariff: price entity '%s' is currently %s", self._price_entity, state.state
+                "Tariff: price entity '%s' quality at startup: %s",
+                self._price_entity, quality,
             )
-        else:
-            try:
-                float(state.state)
-            except (ValueError, TypeError):
-                _LOGGER.warning(
-                    "Tariff: price entity '%s' has non-numeric state '%s'",
-                    self._price_entity, state.state,
-                )
 
     def stop(self) -> None:
         """Unregister all listeners."""
@@ -154,6 +164,73 @@ class TariffChargingManager:
                 self._hass.async_create_task(self._evaluate(state.state))
         self._notify_listeners()
 
+    # ── Price quality ──────────────────────────────────────────────────────
+
+    def _compute_price_quality(self) -> tuple[str, str]:
+        """Return (quality_state, detail_message) without side effects."""
+        state = self._hass.states.get(self._price_entity)
+        if state is None:
+            return QUALITY_NOT_FOUND, f"Entity '{self._price_entity}' not found"
+        if state.state in ("unknown", "unavailable"):
+            return QUALITY_UNAVAILABLE, f"State is '{state.state}'"
+        try:
+            float(state.state)
+        except (ValueError, TypeError):
+            return QUALITY_INVALID, f"Non-numeric state '{state.state}'"
+        if self._price_max_age_minutes is not None:
+            age_seconds = (dt_util.utcnow() - state.last_updated).total_seconds()
+            age_minutes = age_seconds / 60
+            if age_minutes > self._price_max_age_minutes:
+                return (
+                    QUALITY_STALE,
+                    f"Last updated {age_minutes:.0f} min ago (max {self._price_max_age_minutes} min)",
+                )
+        return QUALITY_OK, "ok"
+
+    def _refresh_quality(self) -> bool:
+        """Recompute quality; if changed notify listeners; return True if quality is OK."""
+        quality, detail = self._compute_price_quality()
+        if quality != self._price_quality:
+            prev = self._price_quality
+            self._price_quality = quality
+            _LOGGER.info(
+                "Tariff: price quality changed %s → %s (%s)",
+                prev, quality, detail,
+            )
+            if quality != QUALITY_OK:
+                self._hass.async_create_task(self._handle_bad_quality(detail))
+            self._notify_listeners()
+        return quality == QUALITY_OK
+
+    async def _handle_bad_quality(self, detail: str) -> None:
+        """Stop any active mode when price data quality drops."""
+        stopped_something = False
+        for serial in self._coordinator.serials:
+            if self._charging_active and self._normal_charge_current is not None:
+                _LOGGER.warning(
+                    "Tariff: stopping charging [%s] due to bad price quality — %s", serial, detail
+                )
+                await self._coordinator.async_write_setting(
+                    serial, "chargeCurrent", self._normal_charge_current
+                )
+                self._charging_active = False
+                stopped_something = True
+            if self._discharging_active and self._normal_discharge_current is not None:
+                _LOGGER.warning(
+                    "Tariff: stopping discharging [%s] due to bad price quality — %s", serial, detail
+                )
+                await self._coordinator.async_write_setting(
+                    serial, "dischargeCurrent", self._normal_discharge_current
+                )
+                self._discharging_active = False
+                stopped_something = True
+        if stopped_something:
+            self._send_notification(
+                "Tariff: stopped — price data quality issue",
+                f"Normal currents restored. Reason: {detail}",
+            )
+            self._notify_listeners()
+
     # ── Scheduler ─────────────────────────────────────────────────────────
 
     def _is_in_schedule(self) -> bool:
@@ -173,17 +250,32 @@ class TariffChargingManager:
         new_state = event.data.get("new_state")
         if new_state and new_state.state not in ("unknown", "unavailable"):
             self._hass.async_create_task(self._evaluate(new_state.state))
+        else:
+            # State went unavailable — refresh quality immediately
+            self._refresh_quality()
 
     @callback
     def _on_coordinator_update(self) -> None:
-        state = self._hass.states.get(self._price_entity)
-        if state and state.state not in ("unknown", "unavailable"):
-            self._hass.async_create_task(self._evaluate(state.state))
+        # Periodic quality check (catches staleness between price updates)
+        quality_ok = self._refresh_quality()
+        if quality_ok:
+            state = self._hass.states.get(self._price_entity)
+            if state and state.state not in ("unknown", "unavailable"):
+                self._hass.async_create_task(self._evaluate(state.state))
 
     # ── Core evaluation ────────────────────────────────────────────────────
 
     async def _evaluate(self, price_state: str) -> None:
         if not self._enabled:
+            return
+
+        # Validate quality before acting
+        quality, detail = self._compute_price_quality()
+        if quality != self._price_quality:
+            self._price_quality = quality
+            self._notify_listeners()
+        if quality != QUALITY_OK:
+            await self._handle_bad_quality(detail)
             return
 
         try:
@@ -321,6 +413,10 @@ class TariffChargingManager:
         return self._discharging_active
 
     @property
+    def price_quality(self) -> str:
+        return self._price_quality
+
+    @property
     def mode(self) -> str:
         """Return human-readable current mode."""
         if not self._enabled:
@@ -350,3 +446,7 @@ class TariffChargingManager:
     @property
     def end_hour(self) -> int | None:
         return self._end_hour
+
+    @property
+    def price_max_age_minutes(self) -> int | None:
+        return self._price_max_age_minutes

--- a/custom_components/sunsynk/tariff.py
+++ b/custom_components/sunsynk/tariff.py
@@ -1,0 +1,352 @@
+"""Tariff-aware battery charging/discharging manager."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Callable
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .coordinator import SunsynkCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+_NOTIFICATION_ID = "sunsynk_tariff"
+
+
+class TariffChargingManager:
+    """Monitors a price sensor and adjusts battery charge/discharge current.
+
+    Cheap mode (price ≤ cheap_threshold, SOC < target_soc):
+      → charge at cheap_current.
+    Expensive mode (price ≥ expensive_threshold, SOC > discharge_min_soc):
+      → discharge at peak_discharge_current (sell to grid).
+    Otherwise:
+      → restore normal_charge_current / normal_discharge_current.
+
+    The manager starts DISABLED by default — enable it via the
+    "Tariff Manager" switch entity in HA.
+
+    An optional schedule (start_hour / end_hour) limits activity to
+    specific hours of the day.  If start_hour > end_hour the range
+    wraps midnight (e.g., 22–06).
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: SunsynkCoordinator,
+        price_entity: str,
+        # cheap-rate charging
+        cheap_threshold: float | None,
+        cheap_current: int | None,
+        normal_charge_current: int | None,
+        target_soc: int,
+        # expensive-rate discharging
+        expensive_threshold: float | None,
+        peak_discharge_current: int | None,
+        normal_discharge_current: int | None,
+        discharge_min_soc: int,
+        # schedule (both None = always active)
+        start_hour: int | None = None,
+        end_hour: int | None = None,
+    ) -> None:
+        self._hass = hass
+        self._coordinator = coordinator
+        self._price_entity = price_entity
+
+        self._cheap_threshold = cheap_threshold
+        self._cheap_current = cheap_current
+        self._normal_charge_current = normal_charge_current
+        self._target_soc = target_soc
+
+        self._expensive_threshold = expensive_threshold
+        self._peak_discharge_current = peak_discharge_current
+        self._normal_discharge_current = normal_discharge_current
+        self._discharge_min_soc = discharge_min_soc
+
+        self._start_hour = start_hour
+        self._end_hour = end_hour
+
+        self._enabled = False  # user must explicitly enable via switch
+        self._charging_active = False
+        self._discharging_active = False
+        self._listeners: list[Callable[[], None]] = []
+        self._unsub_price: Any = None
+        self._unsub_coordinator: Any = None
+
+    # ── Listener registry (for switch + sensor entities) ──────────────────
+
+    def async_add_listener(self, cb: Callable[[], None]) -> Callable[[], None]:
+        """Register a callback fired on every state change. Returns unsub."""
+        self._listeners.append(cb)
+        def _remove() -> None:
+            self._listeners.remove(cb)
+        return _remove
+
+    def _notify_listeners(self) -> None:
+        for cb in self._listeners:
+            cb()
+
+    # ── Lifecycle ──────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Register price-sensor and coordinator listeners."""
+        self._unsub_price = async_track_state_change_event(
+            self._hass, [self._price_entity], self._on_price_changed
+        )
+        self._unsub_coordinator = self._coordinator.async_add_listener(
+            self._on_coordinator_update
+        )
+        state = self._hass.states.get(self._price_entity)
+        if state is None:
+            _LOGGER.warning("Tariff: price entity '%s' not found", self._price_entity)
+        elif state.state in ("unknown", "unavailable"):
+            _LOGGER.warning(
+                "Tariff: price entity '%s' is currently %s", self._price_entity, state.state
+            )
+        else:
+            try:
+                float(state.state)
+            except (ValueError, TypeError):
+                _LOGGER.warning(
+                    "Tariff: price entity '%s' has non-numeric state '%s'",
+                    self._price_entity, state.state,
+                )
+
+    def stop(self) -> None:
+        """Unregister all listeners."""
+        if self._unsub_price:
+            self._unsub_price()
+            self._unsub_price = None
+        if self._unsub_coordinator:
+            self._unsub_coordinator()
+            self._unsub_coordinator = None
+
+    # ── Enable / disable ───────────────────────────────────────────────────
+
+    def set_enabled(self, enabled: bool) -> None:
+        """Enable or disable without losing configuration."""
+        self._enabled = enabled
+        if not enabled:
+            for serial in self._coordinator.serials:
+                if self._charging_active and self._normal_charge_current is not None:
+                    self._hass.async_create_task(
+                        self._coordinator.async_write_setting(
+                            serial, "chargeCurrent", self._normal_charge_current
+                        )
+                    )
+                if self._discharging_active and self._normal_discharge_current is not None:
+                    self._hass.async_create_task(
+                        self._coordinator.async_write_setting(
+                            serial, "dischargeCurrent", self._normal_discharge_current
+                        )
+                    )
+            self._charging_active = False
+            self._discharging_active = False
+            _LOGGER.info("Tariff manager disabled — normal currents restored")
+            self._send_notification("Tariff Manager disabled", "Normal charge/discharge currents restored.")
+        else:
+            _LOGGER.info("Tariff manager enabled — re-evaluating current price")
+            state = self._hass.states.get(self._price_entity)
+            if state and state.state not in ("unknown", "unavailable"):
+                self._hass.async_create_task(self._evaluate(state.state))
+        self._notify_listeners()
+
+    # ── Scheduler ─────────────────────────────────────────────────────────
+
+    def _is_in_schedule(self) -> bool:
+        """Return True if current hour is within the configured active window."""
+        if self._start_hour is None or self._end_hour is None:
+            return True
+        hour = datetime.now().hour
+        if self._start_hour <= self._end_hour:
+            return self._start_hour <= hour < self._end_hour
+        # wraps midnight (e.g. 22–06)
+        return hour >= self._start_hour or hour < self._end_hour
+
+    # ── Listeners ──────────────────────────────────────────────────────────
+
+    @callback
+    def _on_price_changed(self, event: Any) -> None:
+        new_state = event.data.get("new_state")
+        if new_state and new_state.state not in ("unknown", "unavailable"):
+            self._hass.async_create_task(self._evaluate(new_state.state))
+
+    @callback
+    def _on_coordinator_update(self) -> None:
+        state = self._hass.states.get(self._price_entity)
+        if state and state.state not in ("unknown", "unavailable"):
+            self._hass.async_create_task(self._evaluate(state.state))
+
+    # ── Core evaluation ────────────────────────────────────────────────────
+
+    async def _evaluate(self, price_state: str) -> None:
+        if not self._enabled:
+            return
+
+        try:
+            price = float(price_state)
+        except (ValueError, TypeError):
+            _LOGGER.debug("Tariff: cannot parse price '%s'", price_state)
+            return
+
+        in_schedule = self._is_in_schedule()
+
+        for serial in self._coordinator.serials:
+            battery = (self._coordinator.data or {}).get(serial, {}).get("battery", {})
+            try:
+                soc = float(battery.get("soc", 0))
+            except (ValueError, TypeError):
+                soc = 0.0
+
+            await self._evaluate_charging(serial, price, soc, in_schedule)
+            await self._evaluate_discharging(serial, price, soc, in_schedule)
+
+    async def _evaluate_charging(
+        self, serial: str, price: float, soc: float, in_schedule: bool
+    ) -> None:
+        if self._cheap_threshold is None or self._cheap_current is None:
+            return
+
+        should_charge = in_schedule and price <= self._cheap_threshold and soc < self._target_soc
+
+        if should_charge and not self._charging_active:
+            _LOGGER.info(
+                "Tariff charging ON [%s] — price %.4f ≤ %.4f, SOC %.0f%% < %d%%",
+                serial, price, self._cheap_threshold, soc, self._target_soc,
+            )
+            await self._coordinator.async_write_setting(
+                serial, "chargeCurrent", self._cheap_current
+            )
+            self._charging_active = True
+            self._send_notification(
+                "Tariff: Charging started",
+                f"Price {price:.4f} ≤ threshold {self._cheap_threshold}. "
+                f"Charging at {self._cheap_current} A until {self._target_soc}% SOC.",
+            )
+            self._notify_listeners()
+
+        elif not should_charge and self._charging_active:
+            if not in_schedule:
+                reason = "outside active schedule"
+            elif price > self._cheap_threshold:
+                reason = f"price {price:.4f} > threshold {self._cheap_threshold}"
+            else:
+                reason = f"SOC {soc:.0f}% reached target {self._target_soc}%"
+            _LOGGER.info("Tariff charging OFF [%s] — %s", serial, reason)
+            await self._coordinator.async_write_setting(
+                serial, "chargeCurrent", self._normal_charge_current
+            )
+            self._charging_active = False
+            self._send_notification(
+                "Tariff: Charging stopped",
+                f"{reason.capitalize()}. Restored {self._normal_charge_current} A.",
+            )
+            self._notify_listeners()
+
+    async def _evaluate_discharging(
+        self, serial: str, price: float, soc: float, in_schedule: bool
+    ) -> None:
+        if self._expensive_threshold is None or self._peak_discharge_current is None:
+            return
+
+        should_discharge = (
+            in_schedule and price >= self._expensive_threshold and soc > self._discharge_min_soc
+        )
+
+        if should_discharge and not self._discharging_active:
+            _LOGGER.info(
+                "Tariff discharging ON [%s] — price %.4f ≥ %.4f, SOC %.0f%% > %d%%",
+                serial, price, self._expensive_threshold, soc, self._discharge_min_soc,
+            )
+            await self._coordinator.async_write_setting(
+                serial, "dischargeCurrent", self._peak_discharge_current
+            )
+            self._discharging_active = True
+            self._send_notification(
+                "Tariff: Discharging started",
+                f"Price {price:.4f} ≥ threshold {self._expensive_threshold}. "
+                f"Discharging at {self._peak_discharge_current} A "
+                f"(min SOC {self._discharge_min_soc}%).",
+            )
+            self._notify_listeners()
+
+        elif not should_discharge and self._discharging_active:
+            if not in_schedule:
+                reason = "outside active schedule"
+            elif price < self._expensive_threshold:
+                reason = f"price {price:.4f} < threshold {self._expensive_threshold}"
+            else:
+                reason = f"SOC {soc:.0f}% reached minimum {self._discharge_min_soc}%"
+            _LOGGER.info("Tariff discharging OFF [%s] — %s", serial, reason)
+            await self._coordinator.async_write_setting(
+                serial, "dischargeCurrent", self._normal_discharge_current
+            )
+            self._discharging_active = False
+            self._send_notification(
+                "Tariff: Discharging stopped",
+                f"{reason.capitalize()}. Restored {self._normal_discharge_current} A.",
+            )
+            self._notify_listeners()
+
+    # ── Notifications ──────────────────────────────────────────────────────
+
+    def _send_notification(self, title: str, message: str) -> None:
+        self._hass.async_create_task(
+            self._hass.services.async_call(
+                "persistent_notification",
+                "create",
+                {
+                    "title": title,
+                    "message": message,
+                    "notification_id": _NOTIFICATION_ID,
+                },
+            )
+        )
+
+    # ── Properties ─────────────────────────────────────────────────────────
+
+    @property
+    def is_enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def is_charging_active(self) -> bool:
+        return self._charging_active
+
+    @property
+    def is_discharging_active(self) -> bool:
+        return self._discharging_active
+
+    @property
+    def mode(self) -> str:
+        """Return human-readable current mode."""
+        if not self._enabled:
+            return "disabled"
+        if self._charging_active:
+            return "charging"
+        if self._discharging_active:
+            return "discharging"
+        return "idle"
+
+    @property
+    def price_entity(self) -> str:
+        return self._price_entity
+
+    @property
+    def cheap_threshold(self) -> float | None:
+        return self._cheap_threshold
+
+    @property
+    def expensive_threshold(self) -> float | None:
+        return self._expensive_threshold
+
+    @property
+    def start_hour(self) -> int | None:
+        return self._start_hour
+
+    @property
+    def end_hour(self) -> int | None:
+        return self._end_hour

--- a/custom_components/sunsynk/translations/en.json
+++ b/custom_components/sunsynk/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Sunsynk / Deye Inverter Setup",
-        "description": "Connect to the Sunsynk cloud API. Separate multiple inverter serial numbers with semicolons (e.g. SN123456;SN789012). MFA is not supported on Sunsynk accounts.",
+        "description": "Connect to the Sunsynk cloud API. Separate multiple inverter serial numbers with semicolons.",
         "data": {
           "api_server": "API Server",
           "username": "Sunsynk Account Email",
@@ -12,15 +12,15 @@
           "refresh_interval": "Refresh Interval (seconds)"
         },
         "data_description": {
-          "serials": "For multiple inverters separate with semicolons: SN123456;SN789012",
-          "refresh_interval": "Minimum 60 seconds, default 300 (5 minutes)"
+          "serials": "For multiple inverters: SN123456;SN789012",
+          "refresh_interval": "How often to poll the Sunsynk API (minimum 60 seconds)"
         }
       }
     },
     "error": {
-      "invalid_auth": "Invalid credentials. Check your Sunsynk email and password. Note: MFA accounts are not supported.",
-      "cannot_connect": "Cannot connect to the Sunsynk API. Check the API server selection and your internet connection.",
-      "invalid_serials": "No valid serial numbers provided. Enter at least one inverter serial."
+      "invalid_auth": "Invalid credentials. Check your Sunsynk email and password.",
+      "cannot_connect": "Cannot connect to the Sunsynk API. Check API server and internet connection.",
+      "invalid_serials": "Invalid serial number(s). Enter at least one serial."
     },
     "abort": {
       "already_configured": "This Sunsynk account is already configured."
@@ -30,28 +30,48 @@
     "step": {
       "init": {
         "title": "Sunsynk Options",
-        "description": "Update inverter serials, refresh interval, or solar forecast settings.",
         "data": {
           "serials": "Inverter Serial Number(s)",
           "refresh_interval": "Refresh Interval (seconds)",
           "latitude": "Latitude (Solar Forecast)",
           "longitude": "Longitude (Solar Forecast)",
           "panel_kwp": "Panel Peak Power (kWp)",
-          "performance_ratio": "Performance Ratio (0–1)"
+          "performance_ratio": "Performance Ratio (0–1)",
+          "price_entity": "Electricity Price Sensor",
+          "cheap_threshold": "Charge below price (cheap rate threshold)",
+          "cheap_charge_current": "Charge current at cheap rate (A)",
+          "normal_charge_current": "Normal charge current to restore (A)",
+          "cheap_target_soc": "Stop charging when SOC reaches (%)",
+          "expensive_threshold": "Discharge above price (expensive rate threshold)",
+          "peak_discharge_current": "Discharge current at expensive rate (A)",
+          "normal_discharge_current": "Normal discharge current to restore (A)",
+          "discharge_min_soc": "Stop discharging when SOC drops below (%)",
+          "tariff_start_hour": "Active schedule — start hour (0–23)",
+          "tariff_end_hour": "Active schedule — end hour (0–23)"
         },
         "data_description": {
-          "serials": "Separate multiple serials with semicolons",
-          "refresh_interval": "Minimum 60 seconds",
           "latitude": "Optional — defaults to your HA home location",
           "longitude": "Optional — defaults to your HA home location",
-          "panel_kwp": "Total installed panel capacity in kilowatt-peak (e.g. 10.5). Leave blank to disable solar forecast.",
-          "performance_ratio": "System efficiency factor accounting for wiring/inverter losses, default 0.80"
+          "panel_kwp": "Total installed panel capacity in kilowatt-peak. Leave blank to disable solar forecast.",
+          "performance_ratio": "System efficiency factor, default 0.80",
+          "price_entity": "Any sensor reporting electricity price (e.g. Octopus Agile, NordPool, Tibber). Leave blank to disable tariff management.",
+          "cheap_threshold": "When price ≤ this value, charge the battery. Leave blank to disable cheap-rate charging.",
+          "cheap_charge_current": "Battery charge current during cheap period (e.g. 100 A).",
+          "normal_charge_current": "Charge current restored when cheap period ends.",
+          "cheap_target_soc": "Charging stops automatically once battery reaches this SOC. Default 100.",
+          "expensive_threshold": "When price ≥ this value, discharge the battery (sell to grid). Leave blank to disable.",
+          "peak_discharge_current": "Battery discharge current during expensive period (e.g. 100 A).",
+          "normal_discharge_current": "Discharge current restored when expensive period ends.",
+          "discharge_min_soc": "Discharging stops automatically when battery reaches this SOC. Default 10.",
+          "tariff_start_hour": "Hour of day (0–23) when tariff management activates. Leave blank for always-on.",
+          "tariff_end_hour": "Hour of day (0–23) when tariff management deactivates. Can wrap midnight (e.g. start 22, end 6)."
         }
       }
     },
     "error": {
-      "invalid_serials": "No valid serial numbers provided.",
-      "invalid_forecast_config": "Solar forecast requires valid latitude, longitude and panel kWp (all numeric, kWp > 0). Leave all three blank to disable."
+      "invalid_serials": "Invalid serial number(s). Enter at least one serial.",
+      "invalid_forecast_config": "Solar forecast requires valid latitude, longitude and panel kWp (all numeric, kWp > 0).",
+      "invalid_tariff_config": "Tariff configuration error. Cheap charging needs threshold + charge current + normal current (all three). Discharge needs threshold + peak current + normal current (all three)."
     }
   }
 }

--- a/custom_components/sunsynk/translations/en.json
+++ b/custom_components/sunsynk/translations/en.json
@@ -47,7 +47,8 @@
           "normal_discharge_current": "Normal discharge current to restore (A)",
           "discharge_min_soc": "Stop discharging when SOC drops below (%)",
           "tariff_start_hour": "Active schedule — start hour (0–23)",
-          "tariff_end_hour": "Active schedule — end hour (0–23)"
+          "tariff_end_hour": "Active schedule — end hour (0–23)",
+          "price_max_age": "Price data max age (minutes)"
         },
         "data_description": {
           "latitude": "Optional — defaults to your HA home location",
@@ -64,7 +65,8 @@
           "normal_discharge_current": "Discharge current restored when expensive period ends.",
           "discharge_min_soc": "Discharging stops automatically when battery reaches this SOC. Default 10.",
           "tariff_start_hour": "Hour of day (0–23) when tariff management activates. Leave blank for always-on.",
-          "tariff_end_hour": "Hour of day (0–23) when tariff management deactivates. Can wrap midnight (e.g. start 22, end 6)."
+          "tariff_end_hour": "Hour of day (0–23) when tariff management deactivates. Can wrap midnight (e.g. start 22, end 6).",
+          "price_max_age": "If the price sensor has not updated within this many minutes, any active charge/discharge mode is stopped as a safety measure. Default 90. Set high to effectively disable the check."
         }
       }
     },

--- a/info.md
+++ b/info.md
@@ -1,0 +1,49 @@
+# Sunsynk / Deye Solar Inverter
+
+Native Home Assistant integration for **Sunsynk** and **Deye / Inteless** solar inverters via the cloud API.
+
+No add-on, no extra YAML — configure everything through the HA UI.
+
+---
+
+## What you get
+
+### ~60 sensor entities per inverter
+PV generation · Battery (SOC, power, temperature, BMS) · Grid (import/export, frequency) · Load · Inverter diagnostics
+
+### ~30 writable number entities
+Charge/discharge current · Battery thresholds · Time slot settings · Zero export · Sell power
+
+### ~25 switch entities
+Solar sell · Battery on · Grid always on · Time slots · Active days
+
+### Solar Forecast (optional)
+6 sensors powered by [Open-Meteo](https://open-meteo.com) — free, no API key:
+- PV yield today & tomorrow (kWh)
+- Cloud cover · Precipitation · GHI · DNI
+
+### Tariff-aware charging & discharging (optional)
+Works with any price sensor — Octopus Agile, NordPool, Tibber, G12:
+- **Cheap rate** → charge battery to target SOC
+- **Expensive rate** → discharge battery (sell to grid)
+- Scheduler, price quality check, HA notifications
+
+### Auto-generated dashboard
+Power flow card + charts + settings — created automatically on first setup.
+
+---
+
+## Supported hardware
+
+| Brand | API server |
+|---|---|
+| Sunsynk | `api.sunsynk.net` |
+| Deye / Inteless | `pv.inteless.com` |
+
+Multi-inverter supported (multiple serial numbers per account).
+
+---
+
+## Documentation
+
+Full documentation is available in the [Wiki](https://github.com/MarcinG81/SunSynk_HA_Integration/wiki).


### PR DESCRIPTION
## Summary

Adds a tariff-aware battery manager that watches any HA electricity price 
sensor and automatically controls charge/discharge current based on 
configurable price thresholds. Works with any operator — Octopus Agile, 
NordPool, Tibber, G12, or a plain `input_number`.

### Cheap-rate charging
When price ≤ threshold **and** SOC < target → raises `chargeCurrent` to 
the configured cheap-rate value. Stops automatically when SOC reaches target 
or price rises above threshold.

### Expensive-rate discharging
When price ≥ threshold **and** SOC > min → raises `dischargeCurrent` (sell 
to grid). Stops when SOC drops to minimum or price falls back.

Both modes are independent — you can use one or both, or neither.

## New entities

| Entity | Type | Description |
|---|---|---|
| Tariff Manager | `switch` | Enable/disable — **starts OFF**, must be turned on manually |
| Tariff Mode | `sensor` | `disabled` / `idle` / `charging` / `discharging` |
| Tariff Price Quality | `sensor` (diagnostic) | `ok` / `stale` / `unavailable` / `invalid` / `not_found` |

## Price data quality check

If the price sensor stops updating (feed goes down), any active mode is 
stopped automatically and normal currents are restored. Configurable max age 
in minutes (default 90). An HA persistent notification is sent on every 
mode change.

## Options

Configured entirely through the HA options flow — no YAML:

- Price sensor (EntitySelector — any `sensor` or `input_number`)
- Cheap threshold, charge current, normal current, target SOC
- Expensive threshold, discharge current, normal discharge current, min SOC
- Active schedule: start hour / end hour (supports midnight wrap e.g. 22–06)
- Price max age (minutes)

## Dashboard

Tariff Manager card automatically added to the auto-generated Overview 
dashboard. History graph (mode + SOC) added to the Charts view.

## Other changes

- Issue templates (bug report, feature request)
- PR template
- `info.md` for HACS UI
- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`

## Testing checklist

- [x] Tariff Manager switch starts OFF after config entry reload
- [x] Cheap charging activates when price drops below threshold
- [x] Cheap charging stops when SOC reaches target
- [x] Expensive discharging activates when price rises above threshold  
- [x] Discharging stops when SOC reaches minimum
- [x] Both modes stop when price sensor goes unavailable/stale
- [x] Scheduler limits activity to configured hours
- [x] Tariff Mode sensor reflects current state in real time
- [x] Price Quality sensor shows `ok` with valid sensor, `stale` after timeout
- [x] HA persistent notification fired on each mode change