### PR TITLE
feat: Tariff-aware battery charging & discharging (v1.6.0–v1.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.6.2] - 2026-05-25
+
+### Fixed
+- `NameError: name 'callback' is not defined` crash in `switch.py` — `callback` was used as a decorator in `TariffManagerSwitch` but never imported from `homeassistant.core`.
+
 ## [1.6.1] - 2026-05-25
 
 ### Fixed
@@ -67,6 +72,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Auto-generated Lovelace dashboard (Power Flow Card bundled — no separate HACS install needed)
 - Sunsynk Power Flow Card v7.3.3 served as a bundled frontend resource
 
+[1.6.2]: https://github.com/MarcinG81/SunSynk_HA_Integration/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/MarcinG81/SunSynk_HA_Integration/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/MarcinG81/SunSynk_HA_Integration/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/MarcinG81/SunSynk_HA_Integration/compare/v1.0.0...v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.6.0] - 2026-05-25
+
+### Added
+- **Tariff-aware charging & discharging** — works with any HA electricity price sensor (Octopus Agile, NordPool, Tibber, G12, `input_number`, etc.):
+  - **Cheap-rate charging**: when price ≤ threshold and SOC < target → raises `chargeCurrent`; stops when SOC reaches target or price rises
+  - **Expensive-rate discharging**: when price ≥ threshold and SOC > min → raises `dischargeCurrent` (sell to grid); stops when SOC hits minimum or price drops
+  - Both modes are independent and optional
+- **Tariff Manager switch** entity — starts **OFF**, must be enabled manually; disabling immediately restores normal currents
+- **Tariff Mode sensor** entity — reports `disabled` / `idle` / `charging` / `discharging` in real time
+- **Tariff Price Quality diagnostic sensor** — reports `ok` / `stale` / `unavailable` / `invalid` / `not_found`; icon changes to alert when data is bad
+- **Price quality check**: if the price sensor stops updating beyond the configured max age (default 90 min), any active mode is stopped and normal currents are restored as a safety measure
+- **Active schedule**: optional start/end hour to limit tariff activity to specific hours of the day (supports midnight wrap, e.g. 22–06)
+- **HA persistent notifications** on every mode change (charging on/off, discharging on/off, manager enabled/disabled, quality issues)
+- Tariff Manager card added to the auto-generated Overview dashboard; history graph (mode + SOC) added to Charts view
+- Issue templates (bug report, feature request) with redirect to Discussions and Wiki
+- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
+- `info.md` — integration description card for HACS UI
+
 ## [1.5.0] - 2026-05-23
 
 ### Added
@@ -44,5 +62,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Auto-generated Lovelace dashboard (Power Flow Card bundled — no separate HACS install needed)
 - Sunsynk Power Flow Card v7.3.3 served as a bundled frontend resource
 
+[1.6.0]: https://github.com/MarcinG81/SunSynk_HA_Integration/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/MarcinG81/SunSynk_HA_Integration/compare/v1.0.0...v1.5.0
 [1.0.0]: https://github.com/MarcinG81/SunSynk_HA_Integration/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.6.1] - 2026-05-25
+
+### Fixed
+- Resolved `Error setting up entry` crash on startup caused by `switch` and `sensor` platforms importing `tariff.py` at module level — HA detects this as a blocking call inside the event loop. Fixed by moving to lazy imports inside `async_setup_entry`.
+
 ## [1.6.0] - 2026-05-25
 
 ### Added
@@ -62,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Auto-generated Lovelace dashboard (Power Flow Card bundled — no separate HACS install needed)
 - Sunsynk Power Flow Card v7.3.3 served as a bundled frontend resource
 
+[1.6.1]: https://github.com/MarcinG81/SunSynk_HA_Integration/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/MarcinG81/SunSynk_HA_Integration/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/MarcinG81/SunSynk_HA_Integration/compare/v1.0.0...v1.5.0
 [1.0.0]: https://github.com/MarcinG81/SunSynk_HA_Integration/releases/tag/v1.0.0

--- a/custom_components/sunsynk/manifest.json
+++ b/custom_components/sunsynk/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/MarcinG81/SunSynk_HA_Integration/issues",
   "requirements": ["cryptography>=38.0.0", "aiohttp>=3.9.0"],
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/custom_components/sunsynk/manifest.json
+++ b/custom_components/sunsynk/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/MarcinG81/SunSynk_HA_Integration/issues",
   "requirements": ["cryptography>=38.0.0", "aiohttp>=3.9.0"],
-  "version": "1.5.0"
+  "version": "1.6.0"
 }

--- a/custom_components/sunsynk/manifest.json
+++ b/custom_components/sunsynk/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/MarcinG81/SunSynk_HA_Integration/issues",
   "requirements": ["cryptography>=38.0.0", "aiohttp>=3.9.0"],
-  "version": "1.6.1"
+  "version": "1.6.2"
 }

--- a/custom_components/sunsynk/sensor.py
+++ b/custom_components/sunsynk/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -33,7 +33,9 @@ from .const import (
 )
 from .coordinator import SolarForecastCoordinator, SunsynkCoordinator
 from .helpers import build_device_info
-from .tariff import QUALITY_OK, TariffChargingManager
+
+if TYPE_CHECKING:
+    from .tariff import TariffChargingManager
 
 
 @dataclass(frozen=True)
@@ -147,6 +149,8 @@ async def async_setup_entry(
             SolarForecastSensor(forecast_coordinator, entry.entry_id, desc, forecast_device)
             for desc in FORECAST_SENSOR_DESCRIPTIONS
         ])
+
+    from .tariff import TariffChargingManager  # lazy import — avoids blocking load at module level
 
     tariff_manager: TariffChargingManager | None = hass.data[DOMAIN].get(
         f"{entry.entry_id}_tariff"
@@ -394,7 +398,7 @@ class TariffPriceQualitySensor(SensorEntity):
     @callback
     def _handle_update(self) -> None:
         quality = self._manager.price_quality
-        self._attr_icon = "mdi:check-circle" if quality == QUALITY_OK else "mdi:alert-circle"
+        self._attr_icon = "mdi:check-circle" if quality == "ok" else "mdi:alert-circle"
         self.async_write_ha_state()
 
     @property

--- a/custom_components/sunsynk/switch.py
+++ b/custom_components/sunsynk/switch.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -15,7 +15,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import SunsynkCoordinator
 from .helpers import build_device_info
-from .tariff import TariffChargingManager
+
+if TYPE_CHECKING:
+    from .tariff import TariffChargingManager
 
 
 @dataclass(frozen=True)
@@ -188,6 +190,8 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
+    from .tariff import TariffChargingManager  # lazy import — avoids blocking load at module level
+
     coordinator: SunsynkCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[SunsynkSwitchEntity | TariffManagerSwitch] = []
 

--- a/custom_components/sunsynk/switch.py
+++ b/custom_components/sunsynk/switch.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback


### PR DESCRIPTION
## Summary

Adds tariff-aware battery management plus community health files and 
two hotfix patches.

## Changes included

### v1.6.0 — Tariff Manager
- Cheap-rate charging: price ≤ threshold → raises `chargeCurrent`
- Expensive-rate discharging: price ≥ threshold → raises `dischargeCurrent`
- Tariff Manager switch entity (starts OFF)
- Tariff Mode sensor: `idle` / `charging` / `discharging` / `disabled`
- Tariff Price Quality diagnostic sensor: `ok` / `stale` / `unavailable` / `invalid`
- Price staleness safety check (default 90 min max age)
- Active schedule with midnight-wrap support
- HA persistent notifications on every mode change
- Tariff cards added to auto-generated dashboard
- Issue templates, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, info.md

### v1.6.1 — Fix blocking import
- Moved tariff module imports to lazy / TYPE_CHECKING pattern to avoid
  blocking import_module detection in HA on Python 3.14

### v1.6.2 — Fix NameError in switch.py
- Added missing `callback` import from `homeassistant.core` —
  `@callback` decorator was used in `TariffManagerSwitch` but never
  imported, crashing the entire switch platform on load

## Testing checklist

- [x] Integration loads without errors in HA log
- [x] Tariff Manager switch appears and starts OFF
- [x] Tariff Mode sensor reports correct state
- [x] Tariff Price Quality sensor shows `ok` with valid price sensor
- [x] Cheap charging activates when price drops below threshold
- [x] Discharging activates when price rises above threshold
- [x] Normal currents restored when manager is disabled