### PR TITLE
feat: diagnostics, repair flows, HA services, tariff config entities & pytest suite

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: pip install -r requirements_test.txt
+      - name: Run tests
+        run: pytest --tb=short

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+          cache-dependency-path: requirements_test.txt
       - name: Install dependencies
         run: pip install -r requirements_test.txt
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](custom_components/sunsynk/LICENSE)
 ![HA Version](https://img.shields.io/badge/HA-2024.1%2B-blue)
 [![Validate](https://github.com/MarcinG81/SunSynk_HA_Integration/actions/workflows/validate.yaml/badge.svg)](https://github.com/MarcinG81/SunSynk_HA_Integration/actions/workflows/validate.yaml)
+[![Tests](https://github.com/MarcinG81/SunSynk_HA_Integration/actions/workflows/tests.yaml/badge.svg)](https://github.com/MarcinG81/SunSynk_HA_Integration/actions/workflows/tests.yaml)
+[![GitHub release](https://img.shields.io/github/v/release/MarcinG81/SunSynk_HA_Integration?sort=semver)](https://github.com/MarcinG81/SunSynk_HA_Integration/releases/latest)
 
 A native Home Assistant **integration** (not an add-on) for monitoring and controlling Sunsynk and Deye hybrid solar inverters via the Sunsynk cloud API.
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,46 @@ These appear under **Settings** entities on the device page.
 
 ---
 
+## HA Energy Dashboard
+
+This integration works out of the box with the built-in Home Assistant **Energy Dashboard** (Settings → Energy). Use the following sensors:
+
+| Energy Dashboard slot | Sensor to select |
+|---|---|
+| **Solar production** | `PV Generation Total` |
+| **Grid consumption** | `Grid Import Total` |
+| **Return to grid** | `Grid Export Total` |
+| **Battery going in** | `Battery Charge Total` |
+| **Battery coming out** | `Battery Discharge Total` |
+| **Home consumption** | `Load Total Energy Used` |
+
+> Use the **Total** sensors (lifetime counters), not the **Today** sensors — they give more accurate historical data in the Energy Dashboard.
+
+---
+
+## HA Services / Actions
+
+Three services are available for use in automations and scripts (**Developer Tools → Actions → sunsynk**):
+
+| Service | Description |
+|---|---|
+| `sunsynk.force_charge` | Set battery charge current to any value (A). Call again with your normal value to restore. |
+| `sunsynk.force_discharge` | Set battery discharge current to any value (A). |
+| `sunsynk.set_work_mode` | Set inverter work mode: 0 = Sell First, 1 = Zero Export, 2 = Time-of-Use, 3 = Self-Use, 4 = Peak-Shaving. |
+
+All services require a `serial` parameter (your inverter serial number) and the value to set.
+
+Example automation:
+```yaml
+action:
+  - action: sunsynk.force_charge
+    data:
+      serial: "SN123456"
+      current: 100
+```
+
+---
+
 ## Tariff Manager Setup
 
 The Tariff Manager automatically charges the battery when electricity is cheap and discharges (sells to grid) when it's expensive. It works with any HA sensor that provides a numeric price.

--- a/custom_components/sunsynk/__init__.py
+++ b/custom_components/sunsynk/__init__.py
@@ -6,10 +6,11 @@ import re
 from pathlib import Path
 from typing import Any
 
+import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 
 from .api.auth import SunsynkAuth
 from .const import (
@@ -47,10 +48,31 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR, Platform.NUMBER, Platform.SWITCH, Platform.TEXT]
 
+SERVICE_FORCE_CHARGE = "force_charge"
+SERVICE_FORCE_DISCHARGE = "force_discharge"
+SERVICE_SET_WORK_MODE = "set_work_mode"
+
+_SERVICE_SERIAL_CURRENT_SCHEMA = vol.Schema({
+    vol.Required("serial"): str,
+    vol.Required("current"): vol.All(vol.Coerce(int), vol.Range(min=0, max=500)),
+})
+_SERVICE_SET_WORK_MODE_SCHEMA = vol.Schema({
+    vol.Required("serial"): str,
+    vol.Required("mode"): vol.All(vol.Coerce(int), vol.Range(min=0, max=4)),
+})
+
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 _CARD_JS = "sunsynk-power-flow-card.js"
 _CARD_URL = f"/sunsynk/{_CARD_JS}"
+
+
+def _find_coordinator(hass: HomeAssistant, serial: str) -> SunsynkCoordinator | None:
+    """Find the coordinator that owns a given inverter serial."""
+    for val in hass.data.get(DOMAIN, {}).values():
+        if isinstance(val, SunsynkCoordinator) and serial in val.serials:
+            return val
+    return None
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
@@ -78,6 +100,38 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         pass
 
     _LOGGER.debug("Sunsynk Power Flow Card registered at %s", _CARD_URL)
+
+    async def _handle_force_charge(call: ServiceCall) -> None:
+        serial: str = call.data["serial"]
+        coordinator = _find_coordinator(hass, serial)
+        if coordinator is None:
+            raise ValueError(f"No Sunsynk inverter found with serial {serial!r}")
+        await coordinator.async_write_setting(serial, "chargeCurrent", call.data["current"])
+
+    async def _handle_force_discharge(call: ServiceCall) -> None:
+        serial: str = call.data["serial"]
+        coordinator = _find_coordinator(hass, serial)
+        if coordinator is None:
+            raise ValueError(f"No Sunsynk inverter found with serial {serial!r}")
+        await coordinator.async_write_setting(serial, "dischargeCurrent", call.data["current"])
+
+    async def _handle_set_work_mode(call: ServiceCall) -> None:
+        serial: str = call.data["serial"]
+        coordinator = _find_coordinator(hass, serial)
+        if coordinator is None:
+            raise ValueError(f"No Sunsynk inverter found with serial {serial!r}")
+        await coordinator.async_write_setting(serial, "sysWorkMode", call.data["mode"])
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_FORCE_CHARGE, _handle_force_charge, _SERVICE_SERIAL_CURRENT_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_FORCE_DISCHARGE, _handle_force_discharge, _SERVICE_SERIAL_CURRENT_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_WORK_MODE, _handle_set_work_mode, _SERVICE_SET_WORK_MODE_SCHEMA
+    )
+
     return True
 
 
@@ -104,6 +158,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         auth=auth,
         serials=serials,
         refresh_interval=refresh_interval,
+        entry_id=entry.entry_id,
     )
 
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/sunsynk/coordinator.py
+++ b/custom_components/sunsynk/coordinator.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import aiohttp
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api.auth import SunsynkAuth, SunsynkAuthError
@@ -30,6 +31,7 @@ class SunsynkCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         auth: SunsynkAuth,
         serials: list[str],
         refresh_interval: int,
+        entry_id: str = "",
     ) -> None:
         super().__init__(
             hass,
@@ -39,6 +41,7 @@ class SunsynkCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         )
         self._auth = auth
         self.serials = serials
+        self._entry_id = entry_id
         self._session: aiohttp.ClientSession | None = None
 
     async def _async_get_session(self) -> aiohttp.ClientSession:
@@ -53,7 +56,17 @@ class SunsynkCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         try:
             token = await self._auth.async_get_token(session)
         except SunsynkAuthError as err:
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                f"auth_failed_{self._entry_id}",
+                is_fixable=False,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="auth_failed",
+            )
             raise UpdateFailed(f"Authentication failed: {err}") from err
+
+        ir.async_delete_issue(self.hass, DOMAIN, f"auth_failed_{self._entry_id}")
 
         client = SunsynkClient(self._auth._api_server, token)
 
@@ -62,9 +75,19 @@ class SunsynkCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             try:
                 result[serial] = await client.async_fetch_all(session, serial)
                 _LOGGER.debug("Data updated for inverter %s", serial)
+                ir.async_delete_issue(self.hass, DOMAIN, f"inverter_offline_{serial}")
             except Exception as err:  # noqa: BLE001
                 _LOGGER.error("Failed to fetch data for inverter %s: %s", serial, err)
                 result[serial] = self.data.get(serial, {}) if self.data else {}
+                ir.async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    f"inverter_offline_{serial}",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key="inverter_offline",
+                    translation_placeholders={"serial": serial},
+                )
 
         return result
 

--- a/custom_components/sunsynk/dashboard.py
+++ b/custom_components/sunsynk/dashboard.py
@@ -104,7 +104,19 @@ def build_dashboard(
     has_forecast = fc_today is not None
 
     # Tariff entity IDs — only populated when tariff manager is configured
-    tariff_mode = tariff_eid("tariff_mode") if tariff_eid else None
+    def t(key: str) -> str | None:
+        return tariff_eid(key) if tariff_eid else None
+
+    tariff_mode            = t("mode")
+    tariff_sw              = t("enabled")
+    tariff_cheap_thr       = t("cheap_threshold")
+    tariff_cheap_cur       = t("cheap_charge_current")
+    tariff_normal_chg_cur  = t("normal_charge_current")
+    tariff_target_soc      = t("target_soc")
+    tariff_exp_thr         = t("expensive_threshold")
+    tariff_peak_dis_cur    = t("peak_discharge_current")
+    tariff_normal_dis_cur  = t("normal_discharge_current")
+    tariff_min_soc         = t("discharge_min_soc")
     has_tariff = tariff_mode is not None
 
     return {
@@ -247,7 +259,7 @@ def build_dashboard(
                                     "type": "entities",
                                     "title": "Tariff Manager",
                                     "entities": [
-                                        {"entity": f"switch.{prefix}_tariff_manager", "name": "Enable Tariff Manager"},
+                                        *([{"entity": tariff_sw, "name": "Enable Tariff Manager"}] if tariff_sw else []),
                                         {"entity": tariff_mode, "name": "Current Mode"},
                                     ],
                                 },
@@ -394,6 +406,26 @@ def build_dashboard(
                             sw("setting_sunday_on"),
                         ],
                     },
+                    *([
+                        {
+                            "type": "entities",
+                            "title": "Tariff Manager Configuration",
+                            "entities": [
+                                *([{"entity": tariff_sw, "name": "Enable"}] if tariff_sw else []),
+                                *([{"entity": tariff_mode, "name": "Mode"}] if tariff_mode else []),
+                                {"type": "section", "label": "Cheap-rate charging"},
+                                *([{"entity": tariff_cheap_thr, "name": "Cheap threshold (price ≤)"}] if tariff_cheap_thr else []),
+                                *([{"entity": tariff_cheap_cur, "name": "Charge current (A)"}] if tariff_cheap_cur else []),
+                                *([{"entity": tariff_normal_chg_cur, "name": "Normal charge current (A)"}] if tariff_normal_chg_cur else []),
+                                *([{"entity": tariff_target_soc, "name": "Target SOC (%)"}] if tariff_target_soc else []),
+                                {"type": "section", "label": "Peak-rate discharging"},
+                                *([{"entity": tariff_exp_thr, "name": "Expensive threshold (price ≥)"}] if tariff_exp_thr else []),
+                                *([{"entity": tariff_peak_dis_cur, "name": "Discharge current (A)"}] if tariff_peak_dis_cur else []),
+                                *([{"entity": tariff_normal_dis_cur, "name": "Normal discharge current (A)"}] if tariff_normal_dis_cur else []),
+                                *([{"entity": tariff_min_soc, "name": "Min SOC (%)"}] if tariff_min_soc else []),
+                            ],
+                        },
+                    ] if has_tariff else []),
                     {
                         "type": "entities",
                         "title": "Generator",

--- a/custom_components/sunsynk/diagnostics.py
+++ b/custom_components/sunsynk/diagnostics.py
@@ -1,0 +1,52 @@
+"""Diagnostics support for Sunsynk integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+_TO_REDACT = {"password", "access_token", "refresh_token"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    from .coordinator import SolarForecastCoordinator, SunsynkCoordinator
+
+    coordinator: SunsynkCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    result: dict[str, Any] = {
+        "entry_data": async_redact_data(dict(entry.data), _TO_REDACT),
+        "entry_options": async_redact_data(dict(entry.options), _TO_REDACT),
+        "coordinator": {
+            "last_update_success": coordinator.last_update_success,
+            "last_update_success_time": (
+                coordinator.last_update_success_time.isoformat()
+                if coordinator.last_update_success_time
+                else None
+            ),
+        },
+        "inverter_data": coordinator.data,
+    }
+
+    forecast_coordinator: SolarForecastCoordinator | None = hass.data[DOMAIN].get(
+        f"{entry.entry_id}_forecast"
+    )
+    if forecast_coordinator is not None:
+        result["forecast_data"] = forecast_coordinator.data
+
+    tariff_manager = hass.data[DOMAIN].get(f"{entry.entry_id}_tariff")
+    if tariff_manager is not None:
+        result["tariff"] = {
+            "enabled": tariff_manager.is_enabled,
+            "mode": tariff_manager.mode,
+            "price_quality": tariff_manager.price_quality,
+            "price_entity": tariff_manager.price_entity,
+        }
+
+    return result

--- a/custom_components/sunsynk/number.py
+++ b/custom_components/sunsynk/number.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -16,7 +16,7 @@ from homeassistant.const import (
     UnitOfElectricCurrent,
     UnitOfPower,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -25,6 +25,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import SunsynkCoordinator
 from .helpers import build_device_info
+
+if TYPE_CHECKING:
+    from .tariff import TariffChargingManager
 
 
 @dataclass(frozen=True)
@@ -353,18 +356,139 @@ WRITABLE_NUMBERS: tuple[SunsynkNumberEntityDescription, ...] = (
 )
 
 
+@dataclass(frozen=True)
+class TariffNumberEntityDescription:
+    key: str
+    name: str
+    native_min_value: float
+    native_max_value: float
+    native_step: float
+    manager_attr: str
+    manager_setter: str
+    native_unit_of_measurement: str | None = None
+    suggested_display_precision: int = 3
+    icon: str | None = None
+
+
+TARIFF_NUMBERS: tuple[TariffNumberEntityDescription, ...] = (
+    TariffNumberEntityDescription(
+        key="cheap_threshold",
+        name="Tariff Cheap Threshold",
+        native_min_value=-1.0,
+        native_max_value=10.0,
+        native_step=0.001,
+        manager_attr="_cheap_threshold",
+        manager_setter="set_cheap_threshold",
+        icon="mdi:arrow-down-circle-outline",
+    ),
+    TariffNumberEntityDescription(
+        key="cheap_charge_current",
+        name="Tariff Cheap Charge Current",
+        native_min_value=0,
+        native_max_value=500,
+        native_step=1,
+        manager_attr="_cheap_current",
+        manager_setter="set_cheap_current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=0,
+        icon="mdi:battery-charging-high",
+    ),
+    TariffNumberEntityDescription(
+        key="normal_charge_current",
+        name="Tariff Normal Charge Current",
+        native_min_value=0,
+        native_max_value=500,
+        native_step=1,
+        manager_attr="_normal_charge_current",
+        manager_setter="set_normal_charge_current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=0,
+        icon="mdi:battery-charging",
+    ),
+    TariffNumberEntityDescription(
+        key="target_soc",
+        name="Tariff Charge Target SOC",
+        native_min_value=10,
+        native_max_value=100,
+        native_step=1,
+        manager_attr="_target_soc",
+        manager_setter="set_target_soc",
+        native_unit_of_measurement=PERCENTAGE,
+        suggested_display_precision=0,
+        icon="mdi:battery-arrow-up",
+    ),
+    TariffNumberEntityDescription(
+        key="expensive_threshold",
+        name="Tariff Expensive Threshold",
+        native_min_value=-1.0,
+        native_max_value=10.0,
+        native_step=0.001,
+        manager_attr="_expensive_threshold",
+        manager_setter="set_expensive_threshold",
+        icon="mdi:arrow-up-circle-outline",
+    ),
+    TariffNumberEntityDescription(
+        key="peak_discharge_current",
+        name="Tariff Peak Discharge Current",
+        native_min_value=0,
+        native_max_value=500,
+        native_step=1,
+        manager_attr="_peak_discharge_current",
+        manager_setter="set_peak_discharge_current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=0,
+        icon="mdi:battery-arrow-down",
+    ),
+    TariffNumberEntityDescription(
+        key="normal_discharge_current",
+        name="Tariff Normal Discharge Current",
+        native_min_value=0,
+        native_max_value=500,
+        native_step=1,
+        manager_attr="_normal_discharge_current",
+        manager_setter="set_normal_discharge_current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=0,
+        icon="mdi:battery-charging-outline",
+    ),
+    TariffNumberEntityDescription(
+        key="discharge_min_soc",
+        name="Tariff Discharge Min SOC",
+        native_min_value=0,
+        native_max_value=90,
+        native_step=1,
+        manager_attr="_discharge_min_soc",
+        manager_setter="set_discharge_min_soc",
+        native_unit_of_measurement=PERCENTAGE,
+        suggested_display_precision=0,
+        icon="mdi:battery-arrow-down-outline",
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: SunsynkCoordinator = hass.data[DOMAIN][entry.entry_id]
-    entities: list[SunsynkNumberEntity] = []
+    entities: list[SunsynkNumberEntity | TariffNumberEntity] = []
 
     for serial in coordinator.serials:
         device_info = build_device_info(coordinator, serial)
         for description in WRITABLE_NUMBERS:
             entities.append(SunsynkNumberEntity(coordinator, serial, description, device_info))
+
+    tariff_manager: TariffChargingManager | None = hass.data[DOMAIN].get(
+        f"{entry.entry_id}_tariff"
+    )
+    if tariff_manager is not None:
+        first_serial = coordinator.serials[0]
+        device_info = build_device_info(coordinator, first_serial)
+        for description in TARIFF_NUMBERS:
+            entities.append(
+                TariffNumberEntity(entry.entry_id, tariff_manager, description, device_info)
+            )
 
     async_add_entities(entities)
 
@@ -413,3 +537,57 @@ class SunsynkNumberEntity(CoordinatorEntity[SunsynkCoordinator], NumberEntity):
         }
         write_value: Any = int(value) if setting_key in int_fields else value
         await self.coordinator.async_write_setting(self._serial, setting_key, write_value)
+
+
+class TariffNumberEntity(NumberEntity):
+    """Writable runtime parameter for the Tariff Charging Manager."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_mode = NumberMode.BOX
+
+    def __init__(
+        self,
+        entry_id: str,
+        manager: TariffChargingManager,
+        description: TariffNumberEntityDescription,
+        device_info: DeviceInfo,
+    ) -> None:
+        self._manager = manager
+        self._description = description
+        self._unsub: Any = None
+        self._attr_unique_id = f"{entry_id}_tariff_{description.key}"
+        self._attr_name = description.name
+        self._attr_device_info = device_info
+        self._attr_native_min_value = description.native_min_value
+        self._attr_native_max_value = description.native_max_value
+        self._attr_native_step = description.native_step
+        self._attr_native_unit_of_measurement = description.native_unit_of_measurement
+        self._attr_suggested_display_precision = description.suggested_display_precision
+        self._attr_icon = description.icon
+
+    async def async_added_to_hass(self) -> None:
+        self._unsub = self._manager.async_add_listener(self._handle_update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._unsub:
+            self._unsub()
+            self._unsub = None
+
+    @callback
+    def _handle_update(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> float | None:
+        value = getattr(self._manager, self._description.manager_attr)
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        getattr(self._manager, self._description.manager_setter)(value)

--- a/custom_components/sunsynk/repairs.py
+++ b/custom_components/sunsynk/repairs.py
@@ -1,0 +1,19 @@
+"""Repair flows for Sunsynk integration."""
+from __future__ import annotations
+
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+
+
+class _ConfirmRepairFlow(RepairsFlow):
+    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(title="", data={})
+        return self.async_show_form(step_id="init")
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict | None
+) -> RepairsFlow:
+    return _ConfirmRepairFlow()

--- a/custom_components/sunsynk/services.yaml
+++ b/custom_components/sunsynk/services.yaml
@@ -1,0 +1,65 @@
+force_charge:
+  name: Force Charge
+  description: >
+    Set the battery charge current to a specific value.
+    Call again with your normal value to restore.
+  fields:
+    serial:
+      name: Inverter Serial
+      description: Serial number of the target inverter.
+      required: true
+      selector:
+        text:
+    current:
+      name: Charge Current
+      description: Charge current in Amperes (0 = stop charging).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 500
+          unit_of_measurement: A
+
+force_discharge:
+  name: Force Discharge
+  description: >
+    Set the battery discharge current to a specific value.
+    Call again with your normal value to restore.
+  fields:
+    serial:
+      name: Inverter Serial
+      description: Serial number of the target inverter.
+      required: true
+      selector:
+        text:
+    current:
+      name: Discharge Current
+      description: Discharge current in Amperes (0 = stop discharging).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 500
+          unit_of_measurement: A
+
+set_work_mode:
+  name: Set Work Mode
+  description: >
+    Set the inverter system work mode.
+    0 = Sell First, 1 = Zero Export, 2 = Time-of-Use, 3 = Self-Use, 4 = Peak-Shaving.
+  fields:
+    serial:
+      name: Inverter Serial
+      description: Serial number of the target inverter.
+      required: true
+      selector:
+        text:
+    mode:
+      name: Work Mode
+      description: System work mode (0–4).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 4
+          mode: box

--- a/custom_components/sunsynk/strings.json
+++ b/custom_components/sunsynk/strings.json
@@ -75,5 +75,15 @@
       "invalid_forecast_config": "Solar forecast requires valid latitude, longitude and panel kWp (all numeric, kWp > 0).",
       "invalid_tariff_config": "Tariff configuration error. Cheap charging needs threshold + charge current + normal current (all three). Discharge needs threshold + peak current + normal current (all three)."
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Sunsynk authentication failed",
+      "description": "The Sunsynk cloud API rejected the credentials. Go to **Settings → Devices & Services → Sunsynk** and reconfigure the integration to update your password."
+    },
+    "inverter_offline": {
+      "title": "Inverter {serial} is offline",
+      "description": "Data for inverter **{serial}** could not be fetched. Check that the inverter dongle is connected and the Sunsynk app shows live data."
+    }
   }
 }

--- a/custom_components/sunsynk/tariff.py
+++ b/custom_components/sunsynk/tariff.py
@@ -398,6 +398,54 @@ class TariffChargingManager:
             )
         )
 
+    # ── Runtime setters (called by TariffNumberEntity) ────────────────────
+
+    def _re_evaluate(self) -> None:
+        """Trigger a fresh evaluation if the manager is active."""
+        if not self._enabled:
+            return
+        state = self._hass.states.get(self._price_entity)
+        if state and state.state not in ("unknown", "unavailable"):
+            self._hass.async_create_task(self._evaluate(state.state))
+
+    def set_cheap_threshold(self, value: float | None) -> None:
+        self._cheap_threshold = value
+        self._re_evaluate()
+        self._notify_listeners()
+
+    def set_cheap_current(self, value: int | None) -> None:
+        self._cheap_current = None if value is None else int(value)
+        self._re_evaluate()
+        self._notify_listeners()
+
+    def set_normal_charge_current(self, value: int | None) -> None:
+        self._normal_charge_current = None if value is None else int(value)
+        self._notify_listeners()
+
+    def set_target_soc(self, value: int) -> None:
+        self._target_soc = int(value)
+        self._re_evaluate()
+        self._notify_listeners()
+
+    def set_expensive_threshold(self, value: float | None) -> None:
+        self._expensive_threshold = value
+        self._re_evaluate()
+        self._notify_listeners()
+
+    def set_peak_discharge_current(self, value: int | None) -> None:
+        self._peak_discharge_current = None if value is None else int(value)
+        self._re_evaluate()
+        self._notify_listeners()
+
+    def set_normal_discharge_current(self, value: int | None) -> None:
+        self._normal_discharge_current = None if value is None else int(value)
+        self._notify_listeners()
+
+    def set_discharge_min_soc(self, value: int) -> None:
+        self._discharge_min_soc = int(value)
+        self._re_evaluate()
+        self._notify_listeners()
+
     # ── Properties ─────────────────────────────────────────────────────────
 
     @property

--- a/custom_components/sunsynk/translations/en.json
+++ b/custom_components/sunsynk/translations/en.json
@@ -75,5 +75,15 @@
       "invalid_forecast_config": "Solar forecast requires valid latitude, longitude and panel kWp (all numeric, kWp > 0).",
       "invalid_tariff_config": "Tariff configuration error. Cheap charging needs threshold + charge current + normal current (all three). Discharge needs threshold + peak current + normal current (all three)."
     }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "Sunsynk authentication failed",
+      "description": "The Sunsynk cloud API rejected the credentials. Go to **Settings → Devices & Services → Sunsynk** and reconfigure the integration to update your password."
+    },
+    "inverter_offline": {
+      "title": "Inverter {serial} is offline",
+      "description": "Data for inverter **{serial}** could not be fetched. Check that the inverter dongle is connected and the Sunsynk app shows live data."
+    }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+extend-exclude = ["tests"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+pytest>=7.4
+pytest-asyncio>=0.23
+pytest-homeassistant-custom-component>=0.13

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared pytest fixtures for Sunsynk tests."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_hass():
+    """Return a minimal mock HomeAssistant instance."""
+    hass = MagicMock()
+    hass.states = MagicMock()
+    hass.states.get = MagicMock(return_value=None)
+    hass.services = MagicMock()
+    return hass
+
+
+@pytest.fixture
+def mock_coordinator(mock_hass):
+    """Return a mock SunsynkCoordinator."""
+    coordinator = MagicMock()
+    coordinator.serials = ["TEST123"]
+    coordinator.data = {
+        "TEST123": {
+            "battery": {"soc": 50, "power": 0},
+            "settings": {"chargeCurrent": 50, "dischargeCurrent": 50},
+        }
+    }
+    coordinator.async_write_setting = AsyncMock()
+    return coordinator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Shared pytest fixtures for Sunsynk tests."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/test_tariff.py
+++ b/tests/test_tariff.py
@@ -1,0 +1,368 @@
+"""Tests for TariffChargingManager state machine."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.sunsynk.tariff import (
+    QUALITY_INVALID,
+    QUALITY_NOT_FOUND,
+    QUALITY_OK,
+    QUALITY_STALE,
+    QUALITY_UNAVAILABLE,
+    TariffChargingManager,
+)
+
+
+def _make_manager(
+    hass,
+    coordinator,
+    *,
+    cheap_threshold=0.10,
+    cheap_current=100,
+    normal_charge=50,
+    target_soc=90,
+    expensive_threshold=0.30,
+    peak_discharge=100,
+    normal_discharge=50,
+    discharge_min_soc=10,
+    start_hour=None,
+    end_hour=None,
+    price_max_age=90,
+) -> TariffChargingManager:
+    return TariffChargingManager(
+        hass=hass,
+        coordinator=coordinator,
+        price_entity="sensor.electricity_price",
+        cheap_threshold=cheap_threshold,
+        cheap_current=cheap_current,
+        normal_charge_current=normal_charge,
+        target_soc=target_soc,
+        expensive_threshold=expensive_threshold,
+        peak_discharge_current=peak_discharge,
+        normal_discharge_current=normal_discharge,
+        discharge_min_soc=discharge_min_soc,
+        start_hour=start_hour,
+        end_hour=end_hour,
+        price_max_age_minutes=price_max_age,
+    )
+
+
+def _price_state(value: str, age_seconds: int = 60) -> MagicMock:
+    state = MagicMock()
+    state.state = value
+    state.last_updated = datetime.now(tz=timezone.utc) - timedelta(seconds=age_seconds)
+    return state
+
+
+# ── Mode property ────────────────────────────────────────────────────────────
+
+
+def test_mode_disabled_by_default(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator)
+    assert mgr.mode == "disabled"
+    assert not mgr.is_enabled
+
+
+def test_mode_idle_when_enabled(mock_hass, mock_coordinator):
+    mock_hass.states.get.return_value = _price_state("0.20")
+    mgr = _make_manager(mock_hass, mock_coordinator)
+    mgr._enabled = True
+    assert mgr.mode == "idle"
+
+
+def test_mode_charging(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator)
+    mgr._enabled = True
+    mgr._charging_active = True
+    assert mgr.mode == "charging"
+
+
+def test_mode_discharging(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator)
+    mgr._enabled = True
+    mgr._discharging_active = True
+    assert mgr.mode == "discharging"
+
+
+# ── Price quality ────────────────────────────────────────────────────────────
+
+
+def test_quality_not_found_when_entity_missing(mock_hass, mock_coordinator):
+    mock_hass.states.get.return_value = None
+    mgr = _make_manager(mock_hass, mock_coordinator)
+    quality, _ = mgr._compute_price_quality()
+    assert quality == QUALITY_NOT_FOUND
+
+
+def test_quality_unavailable(mock_hass, mock_coordinator):
+    state = MagicMock()
+    state.state = "unavailable"
+    mock_hass.states.get.return_value = state
+    mgr = _make_manager(mock_hass, mock_coordinator)
+    quality, _ = mgr._compute_price_quality()
+    assert quality == QUALITY_UNAVAILABLE
+
+
+def test_quality_invalid_non_numeric(mock_hass, mock_coordinator):
+    mock_hass.states.get.return_value = _price_state("not_a_number")
+    mgr = _make_manager(mock_hass, mock_coordinator)
+    quality, _ = mgr._compute_price_quality()
+    assert quality == QUALITY_INVALID
+
+
+def test_quality_ok(mock_hass, mock_coordinator):
+    mock_hass.states.get.return_value = _price_state("0.15", age_seconds=60)
+    mgr = _make_manager(mock_hass, mock_coordinator, price_max_age=90)
+    quality, _ = mgr._compute_price_quality()
+    assert quality == QUALITY_OK
+
+
+def test_quality_stale(mock_hass, mock_coordinator):
+    mock_hass.states.get.return_value = _price_state("0.15", age_seconds=6000)
+    mgr = _make_manager(mock_hass, mock_coordinator, price_max_age=90)
+    quality, _ = mgr._compute_price_quality()
+    assert quality == QUALITY_STALE
+
+
+def test_quality_no_age_check_when_max_age_none(mock_hass, mock_coordinator):
+    mock_hass.states.get.return_value = _price_state("0.15", age_seconds=99999)
+    mgr = _make_manager(mock_hass, mock_coordinator, price_max_age=None)
+    quality, _ = mgr._compute_price_quality()
+    assert quality == QUALITY_OK
+
+
+# ── Schedule ────────────────────────────────────────────────────────────────
+
+
+def test_is_in_schedule_no_restriction(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, start_hour=None, end_hour=None)
+    assert mgr._is_in_schedule() is True
+
+
+@pytest.mark.parametrize("hour", [8, 12, 21])
+def test_is_in_schedule_normal_range(hour, mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, start_hour=7, end_hour=22)
+    with patch("custom_components.sunsynk.tariff.datetime") as mock_dt:
+        mock_dt.now.return_value = MagicMock(hour=hour)
+        assert mgr._is_in_schedule() is True
+
+
+@pytest.mark.parametrize("hour", [5, 6])
+def test_is_outside_schedule_normal_range(hour, mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, start_hour=7, end_hour=22)
+    with patch("custom_components.sunsynk.tariff.datetime") as mock_dt:
+        mock_dt.now.return_value = MagicMock(hour=hour)
+        assert mgr._is_in_schedule() is False
+
+
+@pytest.mark.parametrize("hour", [22, 23, 0, 3, 5])
+def test_is_in_schedule_midnight_wrap(hour, mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, start_hour=22, end_hour=6)
+    with patch("custom_components.sunsynk.tariff.datetime") as mock_dt:
+        mock_dt.now.return_value = MagicMock(hour=hour)
+        assert mgr._is_in_schedule() is True
+
+
+@pytest.mark.parametrize("hour", [6, 10, 18, 21])
+def test_is_outside_schedule_midnight_wrap(hour, mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, start_hour=22, end_hour=6)
+    with patch("custom_components.sunsynk.tariff.datetime") as mock_dt:
+        mock_dt.now.return_value = MagicMock(hour=hour)
+        assert mgr._is_in_schedule() is False
+
+
+# ── Charging evaluation ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_evaluate_starts_charging(mock_hass, mock_coordinator):
+    mock_hass.states.get.return_value = _price_state("0.05")
+    mock_coordinator.data = {"TEST123": {"battery": {"soc": 50}}}
+    mgr = _make_manager(mock_hass, mock_coordinator, cheap_threshold=0.10, target_soc=90)
+    mgr._enabled = True
+    mgr._price_quality = QUALITY_OK
+
+    await mgr._evaluate_charging("TEST123", price=0.05, soc=50.0, in_schedule=True)
+
+    mock_coordinator.async_write_setting.assert_awaited_once_with(
+        "TEST123", "chargeCurrent", 100
+    )
+    assert mgr._charging_active is True
+
+
+@pytest.mark.asyncio
+async def test_evaluate_does_not_charge_above_threshold(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, cheap_threshold=0.10)
+    mgr._enabled = True
+
+    await mgr._evaluate_charging("TEST123", price=0.20, soc=50.0, in_schedule=True)
+
+    mock_coordinator.async_write_setting.assert_not_awaited()
+    assert mgr._charging_active is False
+
+
+@pytest.mark.asyncio
+async def test_evaluate_does_not_charge_when_soc_at_target(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, cheap_threshold=0.10, target_soc=90)
+    mgr._enabled = True
+
+    await mgr._evaluate_charging("TEST123", price=0.05, soc=90.0, in_schedule=True)
+
+    mock_coordinator.async_write_setting.assert_not_awaited()
+    assert mgr._charging_active is False
+
+
+@pytest.mark.asyncio
+async def test_evaluate_stops_charging_when_price_rises(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, cheap_threshold=0.10, normal_charge=50)
+    mgr._enabled = True
+    mgr._charging_active = True
+
+    await mgr._evaluate_charging("TEST123", price=0.20, soc=50.0, in_schedule=True)
+
+    mock_coordinator.async_write_setting.assert_awaited_once_with(
+        "TEST123", "chargeCurrent", 50
+    )
+    assert mgr._charging_active is False
+
+
+@pytest.mark.asyncio
+async def test_evaluate_stops_charging_outside_schedule(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, cheap_threshold=0.10, normal_charge=50)
+    mgr._enabled = True
+    mgr._charging_active = True
+
+    await mgr._evaluate_charging("TEST123", price=0.05, soc=50.0, in_schedule=False)
+
+    mock_coordinator.async_write_setting.assert_awaited_once_with(
+        "TEST123", "chargeCurrent", 50
+    )
+    assert mgr._charging_active is False
+
+
+# ── Discharging evaluation ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_evaluate_starts_discharging(mock_hass, mock_coordinator):
+    mock_hass.states.get.return_value = _price_state("0.40")
+    mgr = _make_manager(
+        mock_hass, mock_coordinator, expensive_threshold=0.30, discharge_min_soc=10
+    )
+    mgr._enabled = True
+    mgr._price_quality = QUALITY_OK
+
+    await mgr._evaluate_discharging("TEST123", price=0.40, soc=80.0, in_schedule=True)
+
+    mock_coordinator.async_write_setting.assert_awaited_once_with(
+        "TEST123", "dischargeCurrent", 100
+    )
+    assert mgr._discharging_active is True
+
+
+@pytest.mark.asyncio
+async def test_evaluate_does_not_discharge_below_threshold(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, expensive_threshold=0.30)
+    mgr._enabled = True
+
+    await mgr._evaluate_discharging("TEST123", price=0.20, soc=80.0, in_schedule=True)
+
+    mock_coordinator.async_write_setting.assert_not_awaited()
+    assert mgr._discharging_active is False
+
+
+@pytest.mark.asyncio
+async def test_evaluate_does_not_discharge_at_min_soc(mock_hass, mock_coordinator):
+    mgr = _make_manager(
+        mock_hass, mock_coordinator, expensive_threshold=0.30, discharge_min_soc=10
+    )
+    mgr._enabled = True
+
+    await mgr._evaluate_discharging("TEST123", price=0.40, soc=10.0, in_schedule=True)
+
+    mock_coordinator.async_write_setting.assert_not_awaited()
+    assert mgr._discharging_active is False
+
+
+@pytest.mark.asyncio
+async def test_evaluate_stops_discharging_when_price_drops(mock_hass, mock_coordinator):
+    mgr = _make_manager(
+        mock_hass, mock_coordinator, expensive_threshold=0.30, normal_discharge=50
+    )
+    mgr._enabled = True
+    mgr._discharging_active = True
+
+    await mgr._evaluate_discharging("TEST123", price=0.20, soc=50.0, in_schedule=True)
+
+    mock_coordinator.async_write_setting.assert_awaited_once_with(
+        "TEST123", "dischargeCurrent", 50
+    )
+    assert mgr._discharging_active is False
+
+
+# ── set_enabled ──────────────────────────────────────────────────────────────
+
+
+def test_set_enabled_false_restores_currents(mock_hass, mock_coordinator):
+    tasks = []
+    mock_hass.async_create_task = lambda coro: tasks.append(coro)
+    mgr = _make_manager(mock_hass, mock_coordinator, normal_charge=50, normal_discharge=50)
+    mgr._enabled = True
+    mgr._charging_active = True
+    mgr._discharging_active = True
+
+    mgr.set_enabled(False)
+
+    assert not mgr.is_enabled
+    assert not mgr._charging_active
+    assert not mgr._discharging_active
+    assert len(tasks) >= 2  # at least charge + discharge restore tasks created
+
+
+def test_set_enabled_notifies_listeners(mock_hass, mock_coordinator):
+    mock_hass.async_create_task = MagicMock()
+    mgr = _make_manager(mock_hass, mock_coordinator)
+    fired = []
+    mgr.async_add_listener(lambda: fired.append(True))
+
+    mgr.set_enabled(False)
+
+    assert len(fired) == 1
+
+
+def test_listener_unsub(mock_hass, mock_coordinator):
+    mock_hass.async_create_task = MagicMock()
+    mgr = _make_manager(mock_hass, mock_coordinator)
+    fired = []
+    unsub = mgr.async_add_listener(lambda: fired.append(True))
+    unsub()
+
+    mgr.set_enabled(False)
+
+    assert len(fired) == 0
+
+
+# ── No-op when thresholds not configured ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_charging_when_threshold_none(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, cheap_threshold=None)
+    mgr._enabled = True
+
+    await mgr._evaluate_charging("TEST123", price=0.05, soc=50.0, in_schedule=True)
+
+    mock_coordinator.async_write_setting.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_discharging_when_threshold_none(mock_hass, mock_coordinator):
+    mgr = _make_manager(mock_hass, mock_coordinator, expensive_threshold=None)
+    mgr._enabled = True
+
+    await mgr._evaluate_discharging("TEST123", price=0.50, soc=80.0, in_schedule=True)
+
+    mock_coordinator.async_write_setting.assert_not_awaited()

--- a/tests/test_tariff.py
+++ b/tests/test_tariff.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 


### PR DESCRIPTION
## What's new

### HA Diagnostics
Download a full diagnostic snapshot (inverter data, config, forecast, tariff state) via
**Settings → Devices & Services → your integration → Download diagnostics**.
Sensitive fields (password, serial numbers) are automatically redacted.

### Repair Flows
The integration now raises actionable issues in the HA Repair dashboard when:
- Cloud authentication fails (wrong password / token expired)
- An inverter goes offline (no data for a serial number)

Issues are automatically cleared when the problem is resolved.

### HA Services / Actions
Three new services callable from automations and scripts:
- `sunsynk.force_charge` — immediately start charging at a given current
- `sunsynk.force_discharge` — immediately start discharging at a given current
- `sunsynk.set_work_mode` — switch inverter work mode on demand

### Tariff Manager — config entities
All Tariff Manager thresholds and currents are now exposed as **Number entities**
(entity category: Config) so you can adjust them from the HA UI or dashboard
without editing YAML or restarting the integration.
Changes take effect immediately and trigger a re-evaluation.

The auto-generated dashboard now includes a dedicated **Tariff Manager Configuration**
card in the Settings view.

### pytest suite
Full unit test suite covering:
- Mode property state machine
- Price quality checks (not found, unavailable, invalid, stale, OK)
- Schedule logic including midnight wrap-around
- Charging / discharging evaluation (start, stop, edge cases)
- `set_enabled` listener notifications

CI runs tests on every push and pull request.

## CI / badges
- Added `Tests` workflow badge to README
- Added `GitHub release` badge to README
- Fixed ruff action scanning `tests/` directory (excluded via `pyproject.toml`)