### PR TITLE
fix: numeric sensors return None instead of raw '--' string

### DIFF
--- a/custom_components/sunsynk/sensor.py
+++ b/custom_components/sunsynk/sensor.py
@@ -292,6 +292,12 @@ class SunsynkSensor(CoordinatorEntity[SunsynkCoordinator], SensorEntity):
         try:
             return float(value)
         except (TypeError, ValueError):
+            # Numeric sensors (state_class set) must report None rather than a raw
+            # string like "--" — the API returns that placeholder for fields that
+            # don't apply to a given inverter, and HA rejects non-numeric values
+            # for measurement/total sensors.
+            if self.entity_description.state_class is not None:
+                return None
             return str(value) if value != "" else None
 
 


### PR DESCRIPTION
## Summary
- The Sunsynk API returns the placeholder string `"--"` for fields like `grid_tip_power` on inverters where that field doesn't apply.
- `SunsynkSensor.native_value` was passing that string straight through as the entity state even for sensors with a numeric `state_class`, which HA rejects and logs as an error — unrelated to any automation that happens to reference a different entity around the same time.
- Sensors with a `state_class` now return `None` when the API value can't be parsed as a number, instead of the raw string. Textual sensors (no `state_class`, e.g. status/serial/version fields) keep their existing string fallback.

Fixes #6

## Test plan
- [x] `python3 -m py_compile custom_components/sunsynk/sensor.py`
- [x] Manual review of all `SunsynkSensorEntityDescription` entries to confirm no numeric-`state_class` sensor relied on the string fallback